### PR TITLE
Changes for landing https://github.com/dart-lang/sdk/issues/32161

### DIFF
--- a/bin/debug_info.dart
+++ b/bin/debug_info.dart
@@ -101,7 +101,7 @@ class _SizeTracker extends RecursiveInfoVisitor {
   final StringBuffer _debugCode = new StringBuffer();
   int _indent = 2;
 
-  _push() => stack.add(new _State());
+  void _push() => stack.add(new _State());
 
   void _pop(info) {
     var last = stack.removeLast();


### PR DESCRIPTION
Add void declarations to methods with implicit dynamic returning void
values, which may be illegal in dart 2, but in either case, expresses
the current intent better.