### PR TITLE
Bump the version of dart2js_info to 0.5.7.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The following tools are a available today:
     `live_code_size_analysis` can correlate that with the `.info.json`, so you
     determine why code that is not used is being included in your app.
 
-  * [`info_json_to_proto`][info_json_to_proto]: a tool that converst `info.json`
+  * [`info_json_to_proto`][info_json_to_proto]: a tool that converts `info.json`
     files generated from dart2js to the protobuf schema defined in `info.proto`.
 
 Next we describe in detail how to use each of these tools.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The following tools are a available today:
     `live_code_size_analysis` can correlate that with the `.info.json`, so you
     determine why code that is not used is being included in your app.
 
+  * [`info_json_to_proto`][info_json_to_proto]: a tool that converst `info.json`
+    files generated from dart2js to the protobuf schema defined in `info.proto`.
+
 Next we describe in detail how to use each of these tools.
 
 ### Code deps tool

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart2js_info
-version: 0.5.6+4
+version: 0.5.6+5
 description: >
   Libraries and tools to process data produced when running dart2js with
   --dump-info.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart2js_info
-version: 0.5.6+5
+version: 0.5.7
 description: >
   Libraries and tools to process data produced when running dart2js with
   --dump-info.


### PR DESCRIPTION
Also adds a description about info_json_to_proto to README.md.