### PR TITLE
Properly type imports when parsing deferredFiles from JSON.

### DIFF
--- a/lib/json_info_codec.dart
+++ b/lib/json_info_codec.dart
@@ -72,8 +72,20 @@ class JsonToAllInfoConverter extends Converter<Map<String, dynamic>, AllInfo> {
     result.program = parseProgram(json['program']);
 
     if (json['deferredFiles'] != null) {
-      result.deferredFiles =
+      final deferredFilesMap =
           (json['deferredFiles'] as Map).cast<String, Map<String, dynamic>>();
+      for (final library in deferredFilesMap.values) {
+        if (library['imports'] != null) {
+          // The importMap needs to be typed as <String, List<String>>, but the
+          // json parser produces <String, dynamic>.
+          final importMap = library['imports'] as Map<String, dynamic>;
+          importMap.forEach((prefix, files) {
+            importMap[prefix] = (files as List<dynamic>).cast<String>();
+          });
+          library['imports'] = importMap.cast<String, List<String>>();
+        }
+      }
+      result.deferredFiles = deferredFilesMap;
     }
 
     // todo: version, etc

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart2js_info
-version: 0.5.8
+version: 0.5.8+1
 description: >
   Libraries and tools to process data produced when running dart2js with
   --dump-info.


### PR DESCRIPTION
The imports list within the deferredFiles map should be typed as `Map<String, List<String>>.` The JSON parser just produces a `Map<String, dynamic>`. To get around this we need to manually cast back `List<String>` and `Map<String, List<String>>`