### PR TITLE
Add structured deferred imports

### DIFF
--- a/info.proto
+++ b/info.proto
@@ -82,6 +82,14 @@ message InfoPB {
 
     /** Information about a closure element. */
     ClosureInfoPB closure_info = 107;
+
+    /**
+     * Information about a deferred import.
+     *
+     * TODO(lorenvs): this is not currently populated by dart2js. Consumers
+     * should prefer deferred_imports on AllInfoPB for the time being.
+     */
+    DeferredImportInfoPB deferred_import_info = 108;
   }
 }
 
@@ -144,6 +152,17 @@ message LibraryInfoPB {
 message OutputUnitInfoPB {
   /** The deferred imports that will load this output unit. */
   repeated string imports = 1;
+
+  /**
+   * The deferred imports that will load this output unit.
+   *
+   * imports above references import names from deferredFiles on AllInfoPB,
+   * whereas these ids reference DeferredImportInfoPBs by id.
+   *   
+   * TODO(lorenvs): this is not currently populated by dart2js. Consumers
+   * should prefer deferred_imports on AllInfoPB for the time being. 
+   */
+  repeated string deferredImportIds = 2;
 }
 
 /** Information about a class element. */
@@ -290,4 +309,15 @@ message LibraryDeferredImportsPB {
 
   /** The individual deferred imports within the library. */
   repeated DeferredImportPB imports = 3;
+}
+
+/**
+ * Information about a deferred import within a dart library.
+ *
+ * TODO(lorenvs): this is not currently populated by dart2js. Consumers
+ * should prefer deferred_imports on AllInfoPB for the time being.
+ */
+message DeferredImportInfoPB {
+  /** The serialized ids of all OutputUnitInfos required by this DeferredImportInfoPB. */
+  repeated string required_output_unit_ids = 1;
 }

--- a/lib/proto_info_codec.dart
+++ b/lib/proto_info_codec.dart
@@ -74,6 +74,8 @@ class AllInfoToProtoConverter extends Converter<AllInfo, AllInfoPB> {
         .addAll(info.topLevelVariables.map((field) => field.serializedId));
     proto.childrenIds.addAll(info.classes.map((clazz) => clazz.serializedId));
     proto.childrenIds.addAll(info.typedefs.map((def) => def.serializedId));
+    proto.childrenIds
+        .addAll(info.deferredImports.map((import) => import.serializedId));
 
     return proto;
   }
@@ -155,6 +157,8 @@ class AllInfoToProtoConverter extends Converter<AllInfo, AllInfoPB> {
   static OutputUnitInfoPB _convertToOutputUnitInfoPB(OutputUnitInfo info) {
     final proto = new OutputUnitInfoPB();
     proto.imports.addAll(info.imports.where((import) => import != null));
+    proto.deferredImportIds
+        .addAll(info.deferredImports.map((import) => import.serializedId));
     return proto;
   }
 
@@ -164,6 +168,14 @@ class AllInfoToProtoConverter extends Converter<AllInfo, AllInfoPB> {
 
   static ClosureInfoPB _convertToClosureInfoPB(ClosureInfo info) {
     return new ClosureInfoPB()..functionId = info.function.serializedId;
+  }
+
+  static DeferredImportInfoPB _convertToDeferredImportInfoPB(
+      DeferredImportInfo info) {
+    final proto = new DeferredImportInfoPB();
+    proto.requiredOutputUnitIds
+        .addAll(info.requiredOutputUnits.map((o) => o.serializedId));
+    return proto;
   }
 
   static InfoPB _convertToInfoPB(Info info) {
@@ -211,6 +223,8 @@ class AllInfoToProtoConverter extends Converter<AllInfo, AllInfoPB> {
       proto.typedefInfo = _convertToTypedefInfoPB(info);
     } else if (info is ClosureInfo) {
       proto.closureInfo = _convertToClosureInfoPB(info);
+    } else if (info is DeferredImportInfo) {
+      proto.deferredImportInfo = _convertToDeferredImportInfoPB(info);
     }
 
     return proto;
@@ -273,6 +287,7 @@ class AllInfoToProtoConverter extends Converter<AllInfo, AllInfoPB> {
     proto.allInfos.addAll(_convertToAllInfosEntries(info.outputUnits));
     proto.allInfos.addAll(_convertToAllInfosEntries(info.typedefs));
     proto.allInfos.addAll(_convertToAllInfosEntries(info.closures));
+    proto.allInfos.addAll(_convertToAllInfosEntries(info.deferredImports));
 
     info.deferredFiles?.forEach((libraryUri, fields) {
       proto.deferredImports

--- a/lib/src/proto/info.pb.dart
+++ b/lib/src/proto/info.pb.dart
@@ -13,118 +13,85 @@ class DependencyInfoPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('DependencyInfoPB')
     ..aOS(1, 'targetId')
     ..aOS(2, 'mask')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   DependencyInfoPB() : super();
-  DependencyInfoPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  DependencyInfoPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  DependencyInfoPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  DependencyInfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   DependencyInfoPB clone() => new DependencyInfoPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static DependencyInfoPB create() => new DependencyInfoPB();
-  static PbList<DependencyInfoPB> createRepeated() =>
-      new PbList<DependencyInfoPB>();
+  static PbList<DependencyInfoPB> createRepeated() => new PbList<DependencyInfoPB>();
   static DependencyInfoPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyDependencyInfoPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyDependencyInfoPB();
     return _defaultInstance;
   }
-
   static DependencyInfoPB _defaultInstance;
   static void $checkItem(DependencyInfoPB v) {
     if (v is! DependencyInfoPB) checkItemFailed(v, 'DependencyInfoPB');
   }
 
   String get targetId => $_getS(0, '');
-  set targetId(String v) {
-    $_setString(0, v);
-  }
-
+  set targetId(String v) { $_setString(0, v); }
   bool hasTargetId() => $_has(0);
   void clearTargetId() => clearField(1);
 
   String get mask => $_getS(1, '');
-  set mask(String v) {
-    $_setString(1, v);
-  }
-
+  set mask(String v) { $_setString(1, v); }
   bool hasMask() => $_has(1);
   void clearMask() => clearField(2);
 }
 
-class _ReadonlyDependencyInfoPB extends DependencyInfoPB
-    with ReadonlyMessageMixin {}
+class _ReadonlyDependencyInfoPB extends DependencyInfoPB with ReadonlyMessageMixin {}
 
 class AllInfoPB_AllInfosEntry extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('AllInfoPB_AllInfosEntry')
     ..aOS(1, 'key')
     ..a<InfoPB>(2, 'value', PbFieldType.OM, InfoPB.getDefault, InfoPB.create)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   AllInfoPB_AllInfosEntry() : super();
-  AllInfoPB_AllInfosEntry.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  AllInfoPB_AllInfosEntry.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  AllInfoPB_AllInfosEntry clone() =>
-      new AllInfoPB_AllInfosEntry()..mergeFromMessage(this);
+  AllInfoPB_AllInfosEntry.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  AllInfoPB_AllInfosEntry.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
+  AllInfoPB_AllInfosEntry clone() => new AllInfoPB_AllInfosEntry()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static AllInfoPB_AllInfosEntry create() => new AllInfoPB_AllInfosEntry();
-  static PbList<AllInfoPB_AllInfosEntry> createRepeated() =>
-      new PbList<AllInfoPB_AllInfosEntry>();
+  static PbList<AllInfoPB_AllInfosEntry> createRepeated() => new PbList<AllInfoPB_AllInfosEntry>();
   static AllInfoPB_AllInfosEntry getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyAllInfoPB_AllInfosEntry();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyAllInfoPB_AllInfosEntry();
     return _defaultInstance;
   }
-
   static AllInfoPB_AllInfosEntry _defaultInstance;
   static void $checkItem(AllInfoPB_AllInfosEntry v) {
-    if (v is! AllInfoPB_AllInfosEntry)
-      checkItemFailed(v, 'AllInfoPB_AllInfosEntry');
+    if (v is! AllInfoPB_AllInfosEntry) checkItemFailed(v, 'AllInfoPB_AllInfosEntry');
   }
 
   String get key => $_getS(0, '');
-  set key(String v) {
-    $_setString(0, v);
-  }
-
+  set key(String v) { $_setString(0, v); }
   bool hasKey() => $_has(0);
   void clearKey() => clearField(1);
 
   InfoPB get value => $_getN(1);
-  set value(InfoPB v) {
-    setField(2, v);
-  }
-
+  set value(InfoPB v) { setField(2, v); }
   bool hasValue() => $_has(1);
   void clearValue() => clearField(2);
 }
 
-class _ReadonlyAllInfoPB_AllInfosEntry extends AllInfoPB_AllInfosEntry
-    with ReadonlyMessageMixin {}
+class _ReadonlyAllInfoPB_AllInfosEntry extends AllInfoPB_AllInfosEntry with ReadonlyMessageMixin {}
 
 class AllInfoPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('AllInfoPB')
-    ..a<ProgramInfoPB>(1, 'program', PbFieldType.OM, ProgramInfoPB.getDefault,
-        ProgramInfoPB.create)
-    ..pp<AllInfoPB_AllInfosEntry>(2, 'allInfos', PbFieldType.PM,
-        AllInfoPB_AllInfosEntry.$checkItem, AllInfoPB_AllInfosEntry.create)
-    ..pp<LibraryDeferredImportsPB>(3, 'deferredImports', PbFieldType.PM,
-        LibraryDeferredImportsPB.$checkItem, LibraryDeferredImportsPB.create)
-    ..hasRequiredFields = false;
+    ..a<ProgramInfoPB>(1, 'program', PbFieldType.OM, ProgramInfoPB.getDefault, ProgramInfoPB.create)
+    ..pp<AllInfoPB_AllInfosEntry>(2, 'allInfos', PbFieldType.PM, AllInfoPB_AllInfosEntry.$checkItem, AllInfoPB_AllInfosEntry.create)
+    ..pp<LibraryDeferredImportsPB>(3, 'deferredImports', PbFieldType.PM, LibraryDeferredImportsPB.$checkItem, LibraryDeferredImportsPB.create)
+    ..hasRequiredFields = false
+  ;
 
   AllInfoPB() : super();
-  AllInfoPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  AllInfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  AllInfoPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  AllInfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   AllInfoPB clone() => new AllInfoPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static AllInfoPB create() => new AllInfoPB();
@@ -133,17 +100,13 @@ class AllInfoPB extends GeneratedMessage {
     if (_defaultInstance == null) _defaultInstance = new _ReadonlyAllInfoPB();
     return _defaultInstance;
   }
-
   static AllInfoPB _defaultInstance;
   static void $checkItem(AllInfoPB v) {
     if (v is! AllInfoPB) checkItemFailed(v, 'AllInfoPB');
   }
 
   ProgramInfoPB get program => $_getN(0);
-  set program(ProgramInfoPB v) {
-    setField(1, v);
-  }
-
+  set program(ProgramInfoPB v) { setField(1, v); }
   bool hasProgram() => $_has(0);
   void clearProgram() => clearField(1);
 
@@ -162,33 +125,23 @@ class InfoPB extends GeneratedMessage {
     ..aOS(4, 'coverageId')
     ..a<int>(5, 'size', PbFieldType.O3)
     ..aOS(6, 'parentId')
-    ..pp<DependencyInfoPB>(7, 'uses', PbFieldType.PM,
-        DependencyInfoPB.$checkItem, DependencyInfoPB.create)
+    ..pp<DependencyInfoPB>(7, 'uses', PbFieldType.PM, DependencyInfoPB.$checkItem, DependencyInfoPB.create)
     ..aOS(8, 'outputUnitId')
-    ..a<LibraryInfoPB>(100, 'libraryInfo', PbFieldType.OM,
-        LibraryInfoPB.getDefault, LibraryInfoPB.create)
-    ..a<ClassInfoPB>(101, 'classInfo', PbFieldType.OM, ClassInfoPB.getDefault,
-        ClassInfoPB.create)
-    ..a<FunctionInfoPB>(102, 'functionInfo', PbFieldType.OM,
-        FunctionInfoPB.getDefault, FunctionInfoPB.create)
-    ..a<FieldInfoPB>(103, 'fieldInfo', PbFieldType.OM, FieldInfoPB.getDefault,
-        FieldInfoPB.create)
-    ..a<ConstantInfoPB>(104, 'constantInfo', PbFieldType.OM,
-        ConstantInfoPB.getDefault, ConstantInfoPB.create)
-    ..a<OutputUnitInfoPB>(105, 'outputUnitInfo', PbFieldType.OM,
-        OutputUnitInfoPB.getDefault, OutputUnitInfoPB.create)
-    ..a<TypedefInfoPB>(106, 'typedefInfo', PbFieldType.OM,
-        TypedefInfoPB.getDefault, TypedefInfoPB.create)
-    ..a<ClosureInfoPB>(107, 'closureInfo', PbFieldType.OM,
-        ClosureInfoPB.getDefault, ClosureInfoPB.create)
-    ..hasRequiredFields = false;
+    ..a<LibraryInfoPB>(100, 'libraryInfo', PbFieldType.OM, LibraryInfoPB.getDefault, LibraryInfoPB.create)
+    ..a<ClassInfoPB>(101, 'classInfo', PbFieldType.OM, ClassInfoPB.getDefault, ClassInfoPB.create)
+    ..a<FunctionInfoPB>(102, 'functionInfo', PbFieldType.OM, FunctionInfoPB.getDefault, FunctionInfoPB.create)
+    ..a<FieldInfoPB>(103, 'fieldInfo', PbFieldType.OM, FieldInfoPB.getDefault, FieldInfoPB.create)
+    ..a<ConstantInfoPB>(104, 'constantInfo', PbFieldType.OM, ConstantInfoPB.getDefault, ConstantInfoPB.create)
+    ..a<OutputUnitInfoPB>(105, 'outputUnitInfo', PbFieldType.OM, OutputUnitInfoPB.getDefault, OutputUnitInfoPB.create)
+    ..a<TypedefInfoPB>(106, 'typedefInfo', PbFieldType.OM, TypedefInfoPB.getDefault, TypedefInfoPB.create)
+    ..a<ClosureInfoPB>(107, 'closureInfo', PbFieldType.OM, ClosureInfoPB.getDefault, ClosureInfoPB.create)
+    ..a<DeferredImportInfoPB>(108, 'deferredImportInfo', PbFieldType.OM, DeferredImportInfoPB.getDefault, DeferredImportInfoPB.create)
+    ..hasRequiredFields = false
+  ;
 
   InfoPB() : super();
-  InfoPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  InfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  InfoPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  InfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   InfoPB clone() => new InfoPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static InfoPB create() => new InfoPB();
@@ -197,133 +150,92 @@ class InfoPB extends GeneratedMessage {
     if (_defaultInstance == null) _defaultInstance = new _ReadonlyInfoPB();
     return _defaultInstance;
   }
-
   static InfoPB _defaultInstance;
   static void $checkItem(InfoPB v) {
     if (v is! InfoPB) checkItemFailed(v, 'InfoPB');
   }
 
   String get name => $_getS(0, '');
-  set name(String v) {
-    $_setString(0, v);
-  }
-
+  set name(String v) { $_setString(0, v); }
   bool hasName() => $_has(0);
   void clearName() => clearField(1);
 
   int get id => $_get(1, 0);
-  set id(int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set id(int v) { $_setSignedInt32(1, v); }
   bool hasId() => $_has(1);
   void clearId() => clearField(2);
 
   String get serializedId => $_getS(2, '');
-  set serializedId(String v) {
-    $_setString(2, v);
-  }
-
+  set serializedId(String v) { $_setString(2, v); }
   bool hasSerializedId() => $_has(2);
   void clearSerializedId() => clearField(3);
 
   String get coverageId => $_getS(3, '');
-  set coverageId(String v) {
-    $_setString(3, v);
-  }
-
+  set coverageId(String v) { $_setString(3, v); }
   bool hasCoverageId() => $_has(3);
   void clearCoverageId() => clearField(4);
 
   int get size => $_get(4, 0);
-  set size(int v) {
-    $_setSignedInt32(4, v);
-  }
-
+  set size(int v) { $_setSignedInt32(4, v); }
   bool hasSize() => $_has(4);
   void clearSize() => clearField(5);
 
   String get parentId => $_getS(5, '');
-  set parentId(String v) {
-    $_setString(5, v);
-  }
-
+  set parentId(String v) { $_setString(5, v); }
   bool hasParentId() => $_has(5);
   void clearParentId() => clearField(6);
 
   List<DependencyInfoPB> get uses => $_getList(6);
 
   String get outputUnitId => $_getS(7, '');
-  set outputUnitId(String v) {
-    $_setString(7, v);
-  }
-
+  set outputUnitId(String v) { $_setString(7, v); }
   bool hasOutputUnitId() => $_has(7);
   void clearOutputUnitId() => clearField(8);
 
   LibraryInfoPB get libraryInfo => $_getN(8);
-  set libraryInfo(LibraryInfoPB v) {
-    setField(100, v);
-  }
-
+  set libraryInfo(LibraryInfoPB v) { setField(100, v); }
   bool hasLibraryInfo() => $_has(8);
   void clearLibraryInfo() => clearField(100);
 
   ClassInfoPB get classInfo => $_getN(9);
-  set classInfo(ClassInfoPB v) {
-    setField(101, v);
-  }
-
+  set classInfo(ClassInfoPB v) { setField(101, v); }
   bool hasClassInfo() => $_has(9);
   void clearClassInfo() => clearField(101);
 
   FunctionInfoPB get functionInfo => $_getN(10);
-  set functionInfo(FunctionInfoPB v) {
-    setField(102, v);
-  }
-
+  set functionInfo(FunctionInfoPB v) { setField(102, v); }
   bool hasFunctionInfo() => $_has(10);
   void clearFunctionInfo() => clearField(102);
 
   FieldInfoPB get fieldInfo => $_getN(11);
-  set fieldInfo(FieldInfoPB v) {
-    setField(103, v);
-  }
-
+  set fieldInfo(FieldInfoPB v) { setField(103, v); }
   bool hasFieldInfo() => $_has(11);
   void clearFieldInfo() => clearField(103);
 
   ConstantInfoPB get constantInfo => $_getN(12);
-  set constantInfo(ConstantInfoPB v) {
-    setField(104, v);
-  }
-
+  set constantInfo(ConstantInfoPB v) { setField(104, v); }
   bool hasConstantInfo() => $_has(12);
   void clearConstantInfo() => clearField(104);
 
   OutputUnitInfoPB get outputUnitInfo => $_getN(13);
-  set outputUnitInfo(OutputUnitInfoPB v) {
-    setField(105, v);
-  }
-
+  set outputUnitInfo(OutputUnitInfoPB v) { setField(105, v); }
   bool hasOutputUnitInfo() => $_has(13);
   void clearOutputUnitInfo() => clearField(105);
 
   TypedefInfoPB get typedefInfo => $_getN(14);
-  set typedefInfo(TypedefInfoPB v) {
-    setField(106, v);
-  }
-
+  set typedefInfo(TypedefInfoPB v) { setField(106, v); }
   bool hasTypedefInfo() => $_has(14);
   void clearTypedefInfo() => clearField(106);
 
   ClosureInfoPB get closureInfo => $_getN(15);
-  set closureInfo(ClosureInfoPB v) {
-    setField(107, v);
-  }
-
+  set closureInfo(ClosureInfoPB v) { setField(107, v); }
   bool hasClosureInfo() => $_has(15);
   void clearClosureInfo() => clearField(107);
+
+  DeferredImportInfoPB get deferredImportInfo => $_getN(16);
+  set deferredImportInfo(DeferredImportInfoPB v) { setField(108, v); }
+  bool hasDeferredImportInfo() => $_has(16);
+  void clearDeferredImportInfo() => clearField(108);
 }
 
 class _ReadonlyInfoPB extends InfoPB with ReadonlyMessageMixin {}
@@ -343,131 +255,87 @@ class ProgramInfoPB extends GeneratedMessage {
     ..aOB(11, 'isFunctionApplyUsed')
     ..aOB(12, 'isMirrorsUsed')
     ..aOB(13, 'minified')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   ProgramInfoPB() : super();
-  ProgramInfoPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  ProgramInfoPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  ProgramInfoPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  ProgramInfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   ProgramInfoPB clone() => new ProgramInfoPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static ProgramInfoPB create() => new ProgramInfoPB();
   static PbList<ProgramInfoPB> createRepeated() => new PbList<ProgramInfoPB>();
   static ProgramInfoPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyProgramInfoPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyProgramInfoPB();
     return _defaultInstance;
   }
-
   static ProgramInfoPB _defaultInstance;
   static void $checkItem(ProgramInfoPB v) {
     if (v is! ProgramInfoPB) checkItemFailed(v, 'ProgramInfoPB');
   }
 
   String get entrypointId => $_getS(0, '');
-  set entrypointId(String v) {
-    $_setString(0, v);
-  }
-
+  set entrypointId(String v) { $_setString(0, v); }
   bool hasEntrypointId() => $_has(0);
   void clearEntrypointId() => clearField(1);
 
   int get size => $_get(1, 0);
-  set size(int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set size(int v) { $_setSignedInt32(1, v); }
   bool hasSize() => $_has(1);
   void clearSize() => clearField(2);
 
   String get dart2jsVersion => $_getS(2, '');
-  set dart2jsVersion(String v) {
-    $_setString(2, v);
-  }
-
+  set dart2jsVersion(String v) { $_setString(2, v); }
   bool hasDart2jsVersion() => $_has(2);
   void clearDart2jsVersion() => clearField(3);
 
   Int64 get compilationMoment => $_getI64(3);
-  set compilationMoment(Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set compilationMoment(Int64 v) { $_setInt64(3, v); }
   bool hasCompilationMoment() => $_has(3);
   void clearCompilationMoment() => clearField(4);
 
   Int64 get compilationDuration => $_getI64(4);
-  set compilationDuration(Int64 v) {
-    $_setInt64(4, v);
-  }
-
+  set compilationDuration(Int64 v) { $_setInt64(4, v); }
   bool hasCompilationDuration() => $_has(4);
   void clearCompilationDuration() => clearField(5);
 
   Int64 get toProtoDuration => $_getI64(5);
-  set toProtoDuration(Int64 v) {
-    $_setInt64(5, v);
-  }
-
+  set toProtoDuration(Int64 v) { $_setInt64(5, v); }
   bool hasToProtoDuration() => $_has(5);
   void clearToProtoDuration() => clearField(6);
 
   Int64 get dumpInfoDuration => $_getI64(6);
-  set dumpInfoDuration(Int64 v) {
-    $_setInt64(6, v);
-  }
-
+  set dumpInfoDuration(Int64 v) { $_setInt64(6, v); }
   bool hasDumpInfoDuration() => $_has(6);
   void clearDumpInfoDuration() => clearField(7);
 
   bool get noSuchMethodEnabled => $_get(7, false);
-  set noSuchMethodEnabled(bool v) {
-    $_setBool(7, v);
-  }
-
+  set noSuchMethodEnabled(bool v) { $_setBool(7, v); }
   bool hasNoSuchMethodEnabled() => $_has(7);
   void clearNoSuchMethodEnabled() => clearField(8);
 
   bool get isRuntimeTypeUsed => $_get(8, false);
-  set isRuntimeTypeUsed(bool v) {
-    $_setBool(8, v);
-  }
-
+  set isRuntimeTypeUsed(bool v) { $_setBool(8, v); }
   bool hasIsRuntimeTypeUsed() => $_has(8);
   void clearIsRuntimeTypeUsed() => clearField(9);
 
   bool get isIsolateUsed => $_get(9, false);
-  set isIsolateUsed(bool v) {
-    $_setBool(9, v);
-  }
-
+  set isIsolateUsed(bool v) { $_setBool(9, v); }
   bool hasIsIsolateUsed() => $_has(9);
   void clearIsIsolateUsed() => clearField(10);
 
   bool get isFunctionApplyUsed => $_get(10, false);
-  set isFunctionApplyUsed(bool v) {
-    $_setBool(10, v);
-  }
-
+  set isFunctionApplyUsed(bool v) { $_setBool(10, v); }
   bool hasIsFunctionApplyUsed() => $_has(10);
   void clearIsFunctionApplyUsed() => clearField(11);
 
   bool get isMirrorsUsed => $_get(11, false);
-  set isMirrorsUsed(bool v) {
-    $_setBool(11, v);
-  }
-
+  set isMirrorsUsed(bool v) { $_setBool(11, v); }
   bool hasIsMirrorsUsed() => $_has(11);
   void clearIsMirrorsUsed() => clearField(12);
 
   bool get minified => $_get(12, false);
-  set minified(bool v) {
-    $_setBool(12, v);
-  }
-
+  set minified(bool v) { $_setBool(12, v); }
   bool hasMinified() => $_has(12);
   void clearMinified() => clearField(13);
 }
@@ -478,35 +346,27 @@ class LibraryInfoPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('LibraryInfoPB')
     ..aOS(1, 'uri')
     ..pPS(2, 'childrenIds')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   LibraryInfoPB() : super();
-  LibraryInfoPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  LibraryInfoPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  LibraryInfoPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  LibraryInfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   LibraryInfoPB clone() => new LibraryInfoPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static LibraryInfoPB create() => new LibraryInfoPB();
   static PbList<LibraryInfoPB> createRepeated() => new PbList<LibraryInfoPB>();
   static LibraryInfoPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyLibraryInfoPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyLibraryInfoPB();
     return _defaultInstance;
   }
-
   static LibraryInfoPB _defaultInstance;
   static void $checkItem(LibraryInfoPB v) {
     if (v is! LibraryInfoPB) checkItemFailed(v, 'LibraryInfoPB');
   }
 
   String get uri => $_getS(0, '');
-  set uri(String v) {
-    $_setString(0, v);
-  }
-
+  set uri(String v) { $_setString(0, v); }
   bool hasUri() => $_has(0);
   void clearUri() => clearField(1);
 
@@ -518,50 +378,43 @@ class _ReadonlyLibraryInfoPB extends LibraryInfoPB with ReadonlyMessageMixin {}
 class OutputUnitInfoPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('OutputUnitInfoPB')
     ..pPS(1, 'imports')
-    ..hasRequiredFields = false;
+    ..pPS(2, 'deferredImportIds')
+    ..hasRequiredFields = false
+  ;
 
   OutputUnitInfoPB() : super();
-  OutputUnitInfoPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  OutputUnitInfoPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  OutputUnitInfoPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  OutputUnitInfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   OutputUnitInfoPB clone() => new OutputUnitInfoPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static OutputUnitInfoPB create() => new OutputUnitInfoPB();
-  static PbList<OutputUnitInfoPB> createRepeated() =>
-      new PbList<OutputUnitInfoPB>();
+  static PbList<OutputUnitInfoPB> createRepeated() => new PbList<OutputUnitInfoPB>();
   static OutputUnitInfoPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyOutputUnitInfoPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyOutputUnitInfoPB();
     return _defaultInstance;
   }
-
   static OutputUnitInfoPB _defaultInstance;
   static void $checkItem(OutputUnitInfoPB v) {
     if (v is! OutputUnitInfoPB) checkItemFailed(v, 'OutputUnitInfoPB');
   }
 
   List<String> get imports => $_getList(0);
+
+  List<String> get deferredImportIds => $_getList(1);
 }
 
-class _ReadonlyOutputUnitInfoPB extends OutputUnitInfoPB
-    with ReadonlyMessageMixin {}
+class _ReadonlyOutputUnitInfoPB extends OutputUnitInfoPB with ReadonlyMessageMixin {}
 
 class ClassInfoPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('ClassInfoPB')
     ..aOB(1, 'isAbstract')
     ..pPS(2, 'childrenIds')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   ClassInfoPB() : super();
-  ClassInfoPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  ClassInfoPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  ClassInfoPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  ClassInfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   ClassInfoPB clone() => new ClassInfoPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static ClassInfoPB create() => new ClassInfoPB();
@@ -570,17 +423,13 @@ class ClassInfoPB extends GeneratedMessage {
     if (_defaultInstance == null) _defaultInstance = new _ReadonlyClassInfoPB();
     return _defaultInstance;
   }
-
   static ClassInfoPB _defaultInstance;
   static void $checkItem(ClassInfoPB v) {
     if (v is! ClassInfoPB) checkItemFailed(v, 'ClassInfoPB');
   }
 
   bool get isAbstract => $_get(0, false);
-  set isAbstract(bool v) {
-    $_setBool(0, v);
-  }
-
+  set isAbstract(bool v) { $_setBool(0, v); }
   bool hasIsAbstract() => $_has(0);
   void clearIsAbstract() => clearField(1);
 
@@ -592,42 +441,32 @@ class _ReadonlyClassInfoPB extends ClassInfoPB with ReadonlyMessageMixin {}
 class ConstantInfoPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('ConstantInfoPB')
     ..aOS(1, 'code')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   ConstantInfoPB() : super();
-  ConstantInfoPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  ConstantInfoPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  ConstantInfoPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  ConstantInfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   ConstantInfoPB clone() => new ConstantInfoPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static ConstantInfoPB create() => new ConstantInfoPB();
-  static PbList<ConstantInfoPB> createRepeated() =>
-      new PbList<ConstantInfoPB>();
+  static PbList<ConstantInfoPB> createRepeated() => new PbList<ConstantInfoPB>();
   static ConstantInfoPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyConstantInfoPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyConstantInfoPB();
     return _defaultInstance;
   }
-
   static ConstantInfoPB _defaultInstance;
   static void $checkItem(ConstantInfoPB v) {
     if (v is! ConstantInfoPB) checkItemFailed(v, 'ConstantInfoPB');
   }
 
   String get code => $_getS(0, '');
-  set code(String v) {
-    $_setString(0, v);
-  }
-
+  set code(String v) { $_setString(0, v); }
   bool hasCode() => $_has(0);
   void clearCode() => clearField(1);
 }
 
-class _ReadonlyConstantInfoPB extends ConstantInfoPB with ReadonlyMessageMixin {
-}
+class _ReadonlyConstantInfoPB extends ConstantInfoPB with ReadonlyMessageMixin {}
 
 class FieldInfoPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('FieldInfoPB')
@@ -637,15 +476,12 @@ class FieldInfoPB extends GeneratedMessage {
     ..aOS(4, 'code')
     ..aOB(5, 'isConst')
     ..aOS(6, 'initializerId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   FieldInfoPB() : super();
-  FieldInfoPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  FieldInfoPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  FieldInfoPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  FieldInfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   FieldInfoPB clone() => new FieldInfoPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static FieldInfoPB create() => new FieldInfoPB();
@@ -654,51 +490,35 @@ class FieldInfoPB extends GeneratedMessage {
     if (_defaultInstance == null) _defaultInstance = new _ReadonlyFieldInfoPB();
     return _defaultInstance;
   }
-
   static FieldInfoPB _defaultInstance;
   static void $checkItem(FieldInfoPB v) {
     if (v is! FieldInfoPB) checkItemFailed(v, 'FieldInfoPB');
   }
 
   String get type => $_getS(0, '');
-  set type(String v) {
-    $_setString(0, v);
-  }
-
+  set type(String v) { $_setString(0, v); }
   bool hasType() => $_has(0);
   void clearType() => clearField(1);
 
   String get inferredType => $_getS(1, '');
-  set inferredType(String v) {
-    $_setString(1, v);
-  }
-
+  set inferredType(String v) { $_setString(1, v); }
   bool hasInferredType() => $_has(1);
   void clearInferredType() => clearField(2);
 
   List<String> get childrenIds => $_getList(2);
 
   String get code => $_getS(3, '');
-  set code(String v) {
-    $_setString(3, v);
-  }
-
+  set code(String v) { $_setString(3, v); }
   bool hasCode() => $_has(3);
   void clearCode() => clearField(4);
 
   bool get isConst => $_get(4, false);
-  set isConst(bool v) {
-    $_setBool(4, v);
-  }
-
+  set isConst(bool v) { $_setBool(4, v); }
   bool hasIsConst() => $_has(4);
   void clearIsConst() => clearField(5);
 
   String get initializerId => $_getS(5, '');
-  set initializerId(String v) {
-    $_setString(5, v);
-  }
-
+  set initializerId(String v) { $_setString(5, v); }
   bool hasInitializerId() => $_has(5);
   void clearInitializerId() => clearField(6);
 }
@@ -708,35 +528,27 @@ class _ReadonlyFieldInfoPB extends FieldInfoPB with ReadonlyMessageMixin {}
 class TypedefInfoPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('TypedefInfoPB')
     ..aOS(1, 'type')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   TypedefInfoPB() : super();
-  TypedefInfoPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  TypedefInfoPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  TypedefInfoPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  TypedefInfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   TypedefInfoPB clone() => new TypedefInfoPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static TypedefInfoPB create() => new TypedefInfoPB();
   static PbList<TypedefInfoPB> createRepeated() => new PbList<TypedefInfoPB>();
   static TypedefInfoPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyTypedefInfoPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyTypedefInfoPB();
     return _defaultInstance;
   }
-
   static TypedefInfoPB _defaultInstance;
   static void $checkItem(TypedefInfoPB v) {
     if (v is! TypedefInfoPB) checkItemFailed(v, 'TypedefInfoPB');
   }
 
   String get type => $_getS(0, '');
-  set type(String v) {
-    $_setString(0, v);
-  }
-
+  set type(String v) { $_setString(0, v); }
   bool hasType() => $_has(0);
   void clearType() => clearField(1);
 }
@@ -749,257 +561,185 @@ class FunctionModifiersPB extends GeneratedMessage {
     ..aOB(2, 'isConst')
     ..aOB(3, 'isFactory')
     ..aOB(4, 'isExternal')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   FunctionModifiersPB() : super();
-  FunctionModifiersPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  FunctionModifiersPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  FunctionModifiersPB clone() =>
-      new FunctionModifiersPB()..mergeFromMessage(this);
+  FunctionModifiersPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  FunctionModifiersPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
+  FunctionModifiersPB clone() => new FunctionModifiersPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static FunctionModifiersPB create() => new FunctionModifiersPB();
-  static PbList<FunctionModifiersPB> createRepeated() =>
-      new PbList<FunctionModifiersPB>();
+  static PbList<FunctionModifiersPB> createRepeated() => new PbList<FunctionModifiersPB>();
   static FunctionModifiersPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyFunctionModifiersPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyFunctionModifiersPB();
     return _defaultInstance;
   }
-
   static FunctionModifiersPB _defaultInstance;
   static void $checkItem(FunctionModifiersPB v) {
     if (v is! FunctionModifiersPB) checkItemFailed(v, 'FunctionModifiersPB');
   }
 
   bool get isStatic => $_get(0, false);
-  set isStatic(bool v) {
-    $_setBool(0, v);
-  }
-
+  set isStatic(bool v) { $_setBool(0, v); }
   bool hasIsStatic() => $_has(0);
   void clearIsStatic() => clearField(1);
 
   bool get isConst => $_get(1, false);
-  set isConst(bool v) {
-    $_setBool(1, v);
-  }
-
+  set isConst(bool v) { $_setBool(1, v); }
   bool hasIsConst() => $_has(1);
   void clearIsConst() => clearField(2);
 
   bool get isFactory => $_get(2, false);
-  set isFactory(bool v) {
-    $_setBool(2, v);
-  }
-
+  set isFactory(bool v) { $_setBool(2, v); }
   bool hasIsFactory() => $_has(2);
   void clearIsFactory() => clearField(3);
 
   bool get isExternal => $_get(3, false);
-  set isExternal(bool v) {
-    $_setBool(3, v);
-  }
-
+  set isExternal(bool v) { $_setBool(3, v); }
   bool hasIsExternal() => $_has(3);
   void clearIsExternal() => clearField(4);
 }
 
-class _ReadonlyFunctionModifiersPB extends FunctionModifiersPB
-    with ReadonlyMessageMixin {}
+class _ReadonlyFunctionModifiersPB extends FunctionModifiersPB with ReadonlyMessageMixin {}
 
 class ParameterInfoPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('ParameterInfoPB')
     ..aOS(1, 'name')
     ..aOS(2, 'type')
     ..aOS(3, 'declaredType')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   ParameterInfoPB() : super();
-  ParameterInfoPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  ParameterInfoPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  ParameterInfoPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  ParameterInfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   ParameterInfoPB clone() => new ParameterInfoPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static ParameterInfoPB create() => new ParameterInfoPB();
-  static PbList<ParameterInfoPB> createRepeated() =>
-      new PbList<ParameterInfoPB>();
+  static PbList<ParameterInfoPB> createRepeated() => new PbList<ParameterInfoPB>();
   static ParameterInfoPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyParameterInfoPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyParameterInfoPB();
     return _defaultInstance;
   }
-
   static ParameterInfoPB _defaultInstance;
   static void $checkItem(ParameterInfoPB v) {
     if (v is! ParameterInfoPB) checkItemFailed(v, 'ParameterInfoPB');
   }
 
   String get name => $_getS(0, '');
-  set name(String v) {
-    $_setString(0, v);
-  }
-
+  set name(String v) { $_setString(0, v); }
   bool hasName() => $_has(0);
   void clearName() => clearField(1);
 
   String get type => $_getS(1, '');
-  set type(String v) {
-    $_setString(1, v);
-  }
-
+  set type(String v) { $_setString(1, v); }
   bool hasType() => $_has(1);
   void clearType() => clearField(2);
 
   String get declaredType => $_getS(2, '');
-  set declaredType(String v) {
-    $_setString(2, v);
-  }
-
+  set declaredType(String v) { $_setString(2, v); }
   bool hasDeclaredType() => $_has(2);
   void clearDeclaredType() => clearField(3);
 }
 
-class _ReadonlyParameterInfoPB extends ParameterInfoPB
-    with ReadonlyMessageMixin {}
+class _ReadonlyParameterInfoPB extends ParameterInfoPB with ReadonlyMessageMixin {}
 
 class MeasurementEntryPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('MeasurementEntryPB')
     ..aOS(1, 'name')
     ..p<int>(2, 'values', PbFieldType.P3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   MeasurementEntryPB() : super();
-  MeasurementEntryPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  MeasurementEntryPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  MeasurementEntryPB clone() =>
-      new MeasurementEntryPB()..mergeFromMessage(this);
+  MeasurementEntryPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  MeasurementEntryPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
+  MeasurementEntryPB clone() => new MeasurementEntryPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static MeasurementEntryPB create() => new MeasurementEntryPB();
-  static PbList<MeasurementEntryPB> createRepeated() =>
-      new PbList<MeasurementEntryPB>();
+  static PbList<MeasurementEntryPB> createRepeated() => new PbList<MeasurementEntryPB>();
   static MeasurementEntryPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyMeasurementEntryPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyMeasurementEntryPB();
     return _defaultInstance;
   }
-
   static MeasurementEntryPB _defaultInstance;
   static void $checkItem(MeasurementEntryPB v) {
     if (v is! MeasurementEntryPB) checkItemFailed(v, 'MeasurementEntryPB');
   }
 
   String get name => $_getS(0, '');
-  set name(String v) {
-    $_setString(0, v);
-  }
-
+  set name(String v) { $_setString(0, v); }
   bool hasName() => $_has(0);
   void clearName() => clearField(1);
 
   List<int> get values => $_getList(1);
 }
 
-class _ReadonlyMeasurementEntryPB extends MeasurementEntryPB
-    with ReadonlyMessageMixin {}
+class _ReadonlyMeasurementEntryPB extends MeasurementEntryPB with ReadonlyMessageMixin {}
 
 class MeasurementCounterPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('MeasurementCounterPB')
     ..aOS(1, 'name')
     ..a<int>(2, 'value', PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   MeasurementCounterPB() : super();
-  MeasurementCounterPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  MeasurementCounterPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  MeasurementCounterPB clone() =>
-      new MeasurementCounterPB()..mergeFromMessage(this);
+  MeasurementCounterPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  MeasurementCounterPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
+  MeasurementCounterPB clone() => new MeasurementCounterPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static MeasurementCounterPB create() => new MeasurementCounterPB();
-  static PbList<MeasurementCounterPB> createRepeated() =>
-      new PbList<MeasurementCounterPB>();
+  static PbList<MeasurementCounterPB> createRepeated() => new PbList<MeasurementCounterPB>();
   static MeasurementCounterPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyMeasurementCounterPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyMeasurementCounterPB();
     return _defaultInstance;
   }
-
   static MeasurementCounterPB _defaultInstance;
   static void $checkItem(MeasurementCounterPB v) {
     if (v is! MeasurementCounterPB) checkItemFailed(v, 'MeasurementCounterPB');
   }
 
   String get name => $_getS(0, '');
-  set name(String v) {
-    $_setString(0, v);
-  }
-
+  set name(String v) { $_setString(0, v); }
   bool hasName() => $_has(0);
   void clearName() => clearField(1);
 
   int get value => $_get(1, 0);
-  set value(int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set value(int v) { $_setSignedInt32(1, v); }
   bool hasValue() => $_has(1);
   void clearValue() => clearField(2);
 }
 
-class _ReadonlyMeasurementCounterPB extends MeasurementCounterPB
-    with ReadonlyMessageMixin {}
+class _ReadonlyMeasurementCounterPB extends MeasurementCounterPB with ReadonlyMessageMixin {}
 
 class MeasurementsPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('MeasurementsPB')
     ..aOS(1, 'sourceFile')
-    ..pp<MeasurementEntryPB>(2, 'entries', PbFieldType.PM,
-        MeasurementEntryPB.$checkItem, MeasurementEntryPB.create)
-    ..pp<MeasurementCounterPB>(3, 'counters', PbFieldType.PM,
-        MeasurementCounterPB.$checkItem, MeasurementCounterPB.create)
-    ..hasRequiredFields = false;
+    ..pp<MeasurementEntryPB>(2, 'entries', PbFieldType.PM, MeasurementEntryPB.$checkItem, MeasurementEntryPB.create)
+    ..pp<MeasurementCounterPB>(3, 'counters', PbFieldType.PM, MeasurementCounterPB.$checkItem, MeasurementCounterPB.create)
+    ..hasRequiredFields = false
+  ;
 
   MeasurementsPB() : super();
-  MeasurementsPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  MeasurementsPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  MeasurementsPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  MeasurementsPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   MeasurementsPB clone() => new MeasurementsPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static MeasurementsPB create() => new MeasurementsPB();
-  static PbList<MeasurementsPB> createRepeated() =>
-      new PbList<MeasurementsPB>();
+  static PbList<MeasurementsPB> createRepeated() => new PbList<MeasurementsPB>();
   static MeasurementsPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyMeasurementsPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyMeasurementsPB();
     return _defaultInstance;
   }
-
   static MeasurementsPB _defaultInstance;
   static void $checkItem(MeasurementsPB v) {
     if (v is! MeasurementsPB) checkItemFailed(v, 'MeasurementsPB');
   }
 
   String get sourceFile => $_getS(0, '');
-  set sourceFile(String v) {
-    $_setString(0, v);
-  }
-
+  set sourceFile(String v) { $_setString(0, v); }
   bool hasSourceFile() => $_has(0);
   void clearSourceFile() => clearField(1);
 
@@ -1008,144 +748,104 @@ class MeasurementsPB extends GeneratedMessage {
   List<MeasurementCounterPB> get counters => $_getList(2);
 }
 
-class _ReadonlyMeasurementsPB extends MeasurementsPB with ReadonlyMessageMixin {
-}
+class _ReadonlyMeasurementsPB extends MeasurementsPB with ReadonlyMessageMixin {}
 
 class FunctionInfoPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('FunctionInfoPB')
-    ..a<FunctionModifiersPB>(1, 'functionModifiers', PbFieldType.OM,
-        FunctionModifiersPB.getDefault, FunctionModifiersPB.create)
+    ..a<FunctionModifiersPB>(1, 'functionModifiers', PbFieldType.OM, FunctionModifiersPB.getDefault, FunctionModifiersPB.create)
     ..pPS(2, 'childrenIds')
     ..aOS(3, 'returnType')
     ..aOS(4, 'inferredReturnType')
-    ..pp<ParameterInfoPB>(5, 'parameters', PbFieldType.PM,
-        ParameterInfoPB.$checkItem, ParameterInfoPB.create)
+    ..pp<ParameterInfoPB>(5, 'parameters', PbFieldType.PM, ParameterInfoPB.$checkItem, ParameterInfoPB.create)
     ..aOS(6, 'sideEffects')
     ..a<int>(7, 'inlinedCount', PbFieldType.O3)
     ..aOS(8, 'code')
-    ..a<MeasurementsPB>(9, 'measurements', PbFieldType.OM,
-        MeasurementsPB.getDefault, MeasurementsPB.create)
-    ..hasRequiredFields = false;
+    ..a<MeasurementsPB>(9, 'measurements', PbFieldType.OM, MeasurementsPB.getDefault, MeasurementsPB.create)
+    ..hasRequiredFields = false
+  ;
 
   FunctionInfoPB() : super();
-  FunctionInfoPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  FunctionInfoPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  FunctionInfoPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  FunctionInfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   FunctionInfoPB clone() => new FunctionInfoPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static FunctionInfoPB create() => new FunctionInfoPB();
-  static PbList<FunctionInfoPB> createRepeated() =>
-      new PbList<FunctionInfoPB>();
+  static PbList<FunctionInfoPB> createRepeated() => new PbList<FunctionInfoPB>();
   static FunctionInfoPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyFunctionInfoPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyFunctionInfoPB();
     return _defaultInstance;
   }
-
   static FunctionInfoPB _defaultInstance;
   static void $checkItem(FunctionInfoPB v) {
     if (v is! FunctionInfoPB) checkItemFailed(v, 'FunctionInfoPB');
   }
 
   FunctionModifiersPB get functionModifiers => $_getN(0);
-  set functionModifiers(FunctionModifiersPB v) {
-    setField(1, v);
-  }
-
+  set functionModifiers(FunctionModifiersPB v) { setField(1, v); }
   bool hasFunctionModifiers() => $_has(0);
   void clearFunctionModifiers() => clearField(1);
 
   List<String> get childrenIds => $_getList(1);
 
   String get returnType => $_getS(2, '');
-  set returnType(String v) {
-    $_setString(2, v);
-  }
-
+  set returnType(String v) { $_setString(2, v); }
   bool hasReturnType() => $_has(2);
   void clearReturnType() => clearField(3);
 
   String get inferredReturnType => $_getS(3, '');
-  set inferredReturnType(String v) {
-    $_setString(3, v);
-  }
-
+  set inferredReturnType(String v) { $_setString(3, v); }
   bool hasInferredReturnType() => $_has(3);
   void clearInferredReturnType() => clearField(4);
 
   List<ParameterInfoPB> get parameters => $_getList(4);
 
   String get sideEffects => $_getS(5, '');
-  set sideEffects(String v) {
-    $_setString(5, v);
-  }
-
+  set sideEffects(String v) { $_setString(5, v); }
   bool hasSideEffects() => $_has(5);
   void clearSideEffects() => clearField(6);
 
   int get inlinedCount => $_get(6, 0);
-  set inlinedCount(int v) {
-    $_setSignedInt32(6, v);
-  }
-
+  set inlinedCount(int v) { $_setSignedInt32(6, v); }
   bool hasInlinedCount() => $_has(6);
   void clearInlinedCount() => clearField(7);
 
   String get code => $_getS(7, '');
-  set code(String v) {
-    $_setString(7, v);
-  }
-
+  set code(String v) { $_setString(7, v); }
   bool hasCode() => $_has(7);
   void clearCode() => clearField(8);
 
   MeasurementsPB get measurements => $_getN(8);
-  set measurements(MeasurementsPB v) {
-    setField(9, v);
-  }
-
+  set measurements(MeasurementsPB v) { setField(9, v); }
   bool hasMeasurements() => $_has(8);
   void clearMeasurements() => clearField(9);
 }
 
-class _ReadonlyFunctionInfoPB extends FunctionInfoPB with ReadonlyMessageMixin {
-}
+class _ReadonlyFunctionInfoPB extends FunctionInfoPB with ReadonlyMessageMixin {}
 
 class ClosureInfoPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('ClosureInfoPB')
     ..aOS(1, 'functionId')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   ClosureInfoPB() : super();
-  ClosureInfoPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  ClosureInfoPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  ClosureInfoPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  ClosureInfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   ClosureInfoPB clone() => new ClosureInfoPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static ClosureInfoPB create() => new ClosureInfoPB();
   static PbList<ClosureInfoPB> createRepeated() => new PbList<ClosureInfoPB>();
   static ClosureInfoPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyClosureInfoPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyClosureInfoPB();
     return _defaultInstance;
   }
-
   static ClosureInfoPB _defaultInstance;
   static void $checkItem(ClosureInfoPB v) {
     if (v is! ClosureInfoPB) checkItemFailed(v, 'ClosureInfoPB');
   }
 
   String get functionId => $_getS(0, '');
-  set functionId(String v) {
-    $_setString(0, v);
-  }
-
+  set functionId(String v) { $_setString(0, v); }
   bool hasFunctionId() => $_has(0);
   void clearFunctionId() => clearField(1);
 }
@@ -1156,96 +856,98 @@ class DeferredImportPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('DeferredImportPB')
     ..aOS(1, 'prefix')
     ..pPS(2, 'files')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   DeferredImportPB() : super();
-  DeferredImportPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  DeferredImportPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  DeferredImportPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  DeferredImportPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
   DeferredImportPB clone() => new DeferredImportPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static DeferredImportPB create() => new DeferredImportPB();
-  static PbList<DeferredImportPB> createRepeated() =>
-      new PbList<DeferredImportPB>();
+  static PbList<DeferredImportPB> createRepeated() => new PbList<DeferredImportPB>();
   static DeferredImportPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyDeferredImportPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyDeferredImportPB();
     return _defaultInstance;
   }
-
   static DeferredImportPB _defaultInstance;
   static void $checkItem(DeferredImportPB v) {
     if (v is! DeferredImportPB) checkItemFailed(v, 'DeferredImportPB');
   }
 
   String get prefix => $_getS(0, '');
-  set prefix(String v) {
-    $_setString(0, v);
-  }
-
+  set prefix(String v) { $_setString(0, v); }
   bool hasPrefix() => $_has(0);
   void clearPrefix() => clearField(1);
 
   List<String> get files => $_getList(1);
 }
 
-class _ReadonlyDeferredImportPB extends DeferredImportPB
-    with ReadonlyMessageMixin {}
+class _ReadonlyDeferredImportPB extends DeferredImportPB with ReadonlyMessageMixin {}
 
 class LibraryDeferredImportsPB extends GeneratedMessage {
   static final BuilderInfo _i = new BuilderInfo('LibraryDeferredImportsPB')
     ..aOS(1, 'libraryUri')
     ..aOS(2, 'libraryName')
-    ..pp<DeferredImportPB>(3, 'imports', PbFieldType.PM,
-        DeferredImportPB.$checkItem, DeferredImportPB.create)
-    ..hasRequiredFields = false;
+    ..pp<DeferredImportPB>(3, 'imports', PbFieldType.PM, DeferredImportPB.$checkItem, DeferredImportPB.create)
+    ..hasRequiredFields = false
+  ;
 
   LibraryDeferredImportsPB() : super();
-  LibraryDeferredImportsPB.fromBuffer(List<int> i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  LibraryDeferredImportsPB.fromJson(String i,
-      [ExtensionRegistry r = ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  LibraryDeferredImportsPB clone() =>
-      new LibraryDeferredImportsPB()..mergeFromMessage(this);
+  LibraryDeferredImportsPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  LibraryDeferredImportsPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
+  LibraryDeferredImportsPB clone() => new LibraryDeferredImportsPB()..mergeFromMessage(this);
   BuilderInfo get info_ => _i;
   static LibraryDeferredImportsPB create() => new LibraryDeferredImportsPB();
-  static PbList<LibraryDeferredImportsPB> createRepeated() =>
-      new PbList<LibraryDeferredImportsPB>();
+  static PbList<LibraryDeferredImportsPB> createRepeated() => new PbList<LibraryDeferredImportsPB>();
   static LibraryDeferredImportsPB getDefault() {
-    if (_defaultInstance == null)
-      _defaultInstance = new _ReadonlyLibraryDeferredImportsPB();
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyLibraryDeferredImportsPB();
     return _defaultInstance;
   }
-
   static LibraryDeferredImportsPB _defaultInstance;
   static void $checkItem(LibraryDeferredImportsPB v) {
-    if (v is! LibraryDeferredImportsPB)
-      checkItemFailed(v, 'LibraryDeferredImportsPB');
+    if (v is! LibraryDeferredImportsPB) checkItemFailed(v, 'LibraryDeferredImportsPB');
   }
 
   String get libraryUri => $_getS(0, '');
-  set libraryUri(String v) {
-    $_setString(0, v);
-  }
-
+  set libraryUri(String v) { $_setString(0, v); }
   bool hasLibraryUri() => $_has(0);
   void clearLibraryUri() => clearField(1);
 
   String get libraryName => $_getS(1, '');
-  set libraryName(String v) {
-    $_setString(1, v);
-  }
-
+  set libraryName(String v) { $_setString(1, v); }
   bool hasLibraryName() => $_has(1);
   void clearLibraryName() => clearField(2);
 
   List<DeferredImportPB> get imports => $_getList(2);
 }
 
-class _ReadonlyLibraryDeferredImportsPB extends LibraryDeferredImportsPB
-    with ReadonlyMessageMixin {}
+class _ReadonlyLibraryDeferredImportsPB extends LibraryDeferredImportsPB with ReadonlyMessageMixin {}
+
+class DeferredImportInfoPB extends GeneratedMessage {
+  static final BuilderInfo _i = new BuilderInfo('DeferredImportInfoPB')
+    ..pPS(1, 'requiredOutputUnitIds')
+    ..hasRequiredFields = false
+  ;
+
+  DeferredImportInfoPB() : super();
+  DeferredImportInfoPB.fromBuffer(List<int> i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
+  DeferredImportInfoPB.fromJson(String i, [ExtensionRegistry r = ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
+  DeferredImportInfoPB clone() => new DeferredImportInfoPB()..mergeFromMessage(this);
+  BuilderInfo get info_ => _i;
+  static DeferredImportInfoPB create() => new DeferredImportInfoPB();
+  static PbList<DeferredImportInfoPB> createRepeated() => new PbList<DeferredImportInfoPB>();
+  static DeferredImportInfoPB getDefault() {
+    if (_defaultInstance == null) _defaultInstance = new _ReadonlyDeferredImportInfoPB();
+    return _defaultInstance;
+  }
+  static DeferredImportInfoPB _defaultInstance;
+  static void $checkItem(DeferredImportInfoPB v) {
+    if (v is! DeferredImportInfoPB) checkItemFailed(v, 'DeferredImportInfoPB');
+  }
+
+  List<String> get requiredOutputUnitIds => $_getList(0);
+}
+
+class _ReadonlyDeferredImportInfoPB extends DeferredImportInfoPB with ReadonlyMessageMixin {}
+

--- a/lib/src/proto/info.pbenum.dart
+++ b/lib/src/proto/info.pbenum.dart
@@ -2,3 +2,4 @@
 //  Generated code. Do not modify.
 ///
 // ignore_for_file: non_constant_identifier_names,library_prefixes
+

--- a/lib/src/proto/info.pbjson.dart
+++ b/lib/src/proto/info.pbjson.dart
@@ -14,30 +14,9 @@ const DependencyInfoPB$json = const {
 const AllInfoPB$json = const {
   '1': 'AllInfoPB',
   '2': const [
-    const {
-      '1': 'program',
-      '3': 1,
-      '4': 1,
-      '5': 11,
-      '6': '.dart2js_info.proto.ProgramInfoPB',
-      '10': 'program'
-    },
-    const {
-      '1': 'all_infos',
-      '3': 2,
-      '4': 3,
-      '5': 11,
-      '6': '.dart2js_info.proto.AllInfoPB.AllInfosEntry',
-      '10': 'allInfos'
-    },
-    const {
-      '1': 'deferred_imports',
-      '3': 3,
-      '4': 3,
-      '5': 11,
-      '6': '.dart2js_info.proto.LibraryDeferredImportsPB',
-      '10': 'deferredImports'
-    },
+    const {'1': 'program', '3': 1, '4': 1, '5': 11, '6': '.dart2js_info.proto.ProgramInfoPB', '10': 'program'},
+    const {'1': 'all_infos', '3': 2, '4': 3, '5': 11, '6': '.dart2js_info.proto.AllInfoPB.AllInfosEntry', '10': 'allInfos'},
+    const {'1': 'deferred_imports', '3': 3, '4': 3, '5': 11, '6': '.dart2js_info.proto.LibraryDeferredImportsPB', '10': 'deferredImports'},
   ],
   '3': const [AllInfoPB_AllInfosEntry$json],
 };
@@ -46,14 +25,7 @@ const AllInfoPB_AllInfosEntry$json = const {
   '1': 'AllInfosEntry',
   '2': const [
     const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {
-      '1': 'value',
-      '3': 2,
-      '4': 1,
-      '5': 11,
-      '6': '.dart2js_info.proto.InfoPB',
-      '10': 'value'
-    },
+    const {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.dart2js_info.proto.InfoPB', '10': 'value'},
   ],
   '7': const {'7': true},
 };
@@ -67,87 +39,17 @@ const InfoPB$json = const {
     const {'1': 'coverage_id', '3': 4, '4': 1, '5': 9, '10': 'coverageId'},
     const {'1': 'size', '3': 5, '4': 1, '5': 5, '10': 'size'},
     const {'1': 'parent_id', '3': 6, '4': 1, '5': 9, '10': 'parentId'},
-    const {
-      '1': 'uses',
-      '3': 7,
-      '4': 3,
-      '5': 11,
-      '6': '.dart2js_info.proto.DependencyInfoPB',
-      '10': 'uses'
-    },
+    const {'1': 'uses', '3': 7, '4': 3, '5': 11, '6': '.dart2js_info.proto.DependencyInfoPB', '10': 'uses'},
     const {'1': 'output_unit_id', '3': 8, '4': 1, '5': 9, '10': 'outputUnitId'},
-    const {
-      '1': 'library_info',
-      '3': 100,
-      '4': 1,
-      '5': 11,
-      '6': '.dart2js_info.proto.LibraryInfoPB',
-      '9': 0,
-      '10': 'libraryInfo'
-    },
-    const {
-      '1': 'class_info',
-      '3': 101,
-      '4': 1,
-      '5': 11,
-      '6': '.dart2js_info.proto.ClassInfoPB',
-      '9': 0,
-      '10': 'classInfo'
-    },
-    const {
-      '1': 'function_info',
-      '3': 102,
-      '4': 1,
-      '5': 11,
-      '6': '.dart2js_info.proto.FunctionInfoPB',
-      '9': 0,
-      '10': 'functionInfo'
-    },
-    const {
-      '1': 'field_info',
-      '3': 103,
-      '4': 1,
-      '5': 11,
-      '6': '.dart2js_info.proto.FieldInfoPB',
-      '9': 0,
-      '10': 'fieldInfo'
-    },
-    const {
-      '1': 'constant_info',
-      '3': 104,
-      '4': 1,
-      '5': 11,
-      '6': '.dart2js_info.proto.ConstantInfoPB',
-      '9': 0,
-      '10': 'constantInfo'
-    },
-    const {
-      '1': 'output_unit_info',
-      '3': 105,
-      '4': 1,
-      '5': 11,
-      '6': '.dart2js_info.proto.OutputUnitInfoPB',
-      '9': 0,
-      '10': 'outputUnitInfo'
-    },
-    const {
-      '1': 'typedef_info',
-      '3': 106,
-      '4': 1,
-      '5': 11,
-      '6': '.dart2js_info.proto.TypedefInfoPB',
-      '9': 0,
-      '10': 'typedefInfo'
-    },
-    const {
-      '1': 'closure_info',
-      '3': 107,
-      '4': 1,
-      '5': 11,
-      '6': '.dart2js_info.proto.ClosureInfoPB',
-      '9': 0,
-      '10': 'closureInfo'
-    },
+    const {'1': 'library_info', '3': 100, '4': 1, '5': 11, '6': '.dart2js_info.proto.LibraryInfoPB', '9': 0, '10': 'libraryInfo'},
+    const {'1': 'class_info', '3': 101, '4': 1, '5': 11, '6': '.dart2js_info.proto.ClassInfoPB', '9': 0, '10': 'classInfo'},
+    const {'1': 'function_info', '3': 102, '4': 1, '5': 11, '6': '.dart2js_info.proto.FunctionInfoPB', '9': 0, '10': 'functionInfo'},
+    const {'1': 'field_info', '3': 103, '4': 1, '5': 11, '6': '.dart2js_info.proto.FieldInfoPB', '9': 0, '10': 'fieldInfo'},
+    const {'1': 'constant_info', '3': 104, '4': 1, '5': 11, '6': '.dart2js_info.proto.ConstantInfoPB', '9': 0, '10': 'constantInfo'},
+    const {'1': 'output_unit_info', '3': 105, '4': 1, '5': 11, '6': '.dart2js_info.proto.OutputUnitInfoPB', '9': 0, '10': 'outputUnitInfo'},
+    const {'1': 'typedef_info', '3': 106, '4': 1, '5': 11, '6': '.dart2js_info.proto.TypedefInfoPB', '9': 0, '10': 'typedefInfo'},
+    const {'1': 'closure_info', '3': 107, '4': 1, '5': 11, '6': '.dart2js_info.proto.ClosureInfoPB', '9': 0, '10': 'closureInfo'},
+    const {'1': 'deferred_import_info', '3': 108, '4': 1, '5': 11, '6': '.dart2js_info.proto.DeferredImportInfoPB', '9': 0, '10': 'deferredImportInfo'},
   ],
   '8': const [
     const {'1': 'concrete'},
@@ -162,76 +64,16 @@ const ProgramInfoPB$json = const {
   '2': const [
     const {'1': 'entrypoint_id', '3': 1, '4': 1, '5': 9, '10': 'entrypointId'},
     const {'1': 'size', '3': 2, '4': 1, '5': 5, '10': 'size'},
-    const {
-      '1': 'dart2js_version',
-      '3': 3,
-      '4': 1,
-      '5': 9,
-      '10': 'dart2jsVersion'
-    },
-    const {
-      '1': 'compilation_moment',
-      '3': 4,
-      '4': 1,
-      '5': 3,
-      '10': 'compilationMoment'
-    },
-    const {
-      '1': 'compilation_duration',
-      '3': 5,
-      '4': 1,
-      '5': 3,
-      '10': 'compilationDuration'
-    },
-    const {
-      '1': 'to_proto_duration',
-      '3': 6,
-      '4': 1,
-      '5': 3,
-      '10': 'toProtoDuration'
-    },
-    const {
-      '1': 'dump_info_duration',
-      '3': 7,
-      '4': 1,
-      '5': 3,
-      '10': 'dumpInfoDuration'
-    },
-    const {
-      '1': 'no_such_method_enabled',
-      '3': 8,
-      '4': 1,
-      '5': 8,
-      '10': 'noSuchMethodEnabled'
-    },
-    const {
-      '1': 'is_runtime_type_used',
-      '3': 9,
-      '4': 1,
-      '5': 8,
-      '10': 'isRuntimeTypeUsed'
-    },
-    const {
-      '1': 'is_isolate_used',
-      '3': 10,
-      '4': 1,
-      '5': 8,
-      '10': 'isIsolateUsed'
-    },
-    const {
-      '1': 'is_function_apply_used',
-      '3': 11,
-      '4': 1,
-      '5': 8,
-      '10': 'isFunctionApplyUsed'
-    },
-    const {
-      '1': 'is_mirrors_used',
-      '3': 12,
-      '4': 1,
-      '5': 8,
-      '10': 'isMirrorsUsed'
-    },
+    const {'1': 'dart2js_version', '3': 3, '4': 1, '5': 9, '10': 'dart2jsVersion'},
+    const {'1': 'compilation_moment', '3': 4, '4': 1, '5': 3, '10': 'compilationMoment'},
+    const {'1': 'compilation_duration', '3': 5, '4': 1, '5': 3, '10': 'compilationDuration'},
+    const {'1': 'to_proto_duration', '3': 6, '4': 1, '5': 3, '10': 'toProtoDuration'},
+    const {'1': 'dump_info_duration', '3': 7, '4': 1, '5': 3, '10': 'dumpInfoDuration'},
+    const {'1': 'no_such_method_enabled', '3': 8, '4': 1, '5': 8, '10': 'noSuchMethodEnabled'},
+    const {'1': 'is_runtime_type_used', '3': 9, '4': 1, '5': 8, '10': 'isRuntimeTypeUsed'},
+    const {'1': 'is_isolate_used', '3': 10, '4': 1, '5': 8, '10': 'isIsolateUsed'},
+    const {'1': 'is_function_apply_used', '3': 11, '4': 1, '5': 8, '10': 'isFunctionApplyUsed'},
+    const {'1': 'is_mirrors_used', '3': 12, '4': 1, '5': 8, '10': 'isMirrorsUsed'},
     const {'1': 'minified', '3': 13, '4': 1, '5': 8, '10': 'minified'},
   ],
 };
@@ -248,6 +90,7 @@ const OutputUnitInfoPB$json = const {
   '1': 'OutputUnitInfoPB',
   '2': const [
     const {'1': 'imports', '3': 1, '4': 3, '5': 9, '10': 'imports'},
+    const {'1': 'deferredImportIds', '3': 2, '4': 3, '5': 9, '10': 'deferredImportIds'},
   ],
 };
 
@@ -274,13 +117,7 @@ const FieldInfoPB$json = const {
     const {'1': 'children_ids', '3': 3, '4': 3, '5': 9, '10': 'childrenIds'},
     const {'1': 'code', '3': 4, '4': 1, '5': 9, '10': 'code'},
     const {'1': 'is_const', '3': 5, '4': 1, '5': 8, '10': 'isConst'},
-    const {
-      '1': 'initializer_id',
-      '3': 6,
-      '4': 1,
-      '5': 9,
-      '10': 'initializerId'
-    },
+    const {'1': 'initializer_id', '3': 6, '4': 1, '5': 9, '10': 'initializerId'},
   ],
 };
 
@@ -330,64 +167,23 @@ const MeasurementsPB$json = const {
   '1': 'MeasurementsPB',
   '2': const [
     const {'1': 'source_file', '3': 1, '4': 1, '5': 9, '10': 'sourceFile'},
-    const {
-      '1': 'entries',
-      '3': 2,
-      '4': 3,
-      '5': 11,
-      '6': '.dart2js_info.proto.MeasurementEntryPB',
-      '10': 'entries'
-    },
-    const {
-      '1': 'counters',
-      '3': 3,
-      '4': 3,
-      '5': 11,
-      '6': '.dart2js_info.proto.MeasurementCounterPB',
-      '10': 'counters'
-    },
+    const {'1': 'entries', '3': 2, '4': 3, '5': 11, '6': '.dart2js_info.proto.MeasurementEntryPB', '10': 'entries'},
+    const {'1': 'counters', '3': 3, '4': 3, '5': 11, '6': '.dart2js_info.proto.MeasurementCounterPB', '10': 'counters'},
   ],
 };
 
 const FunctionInfoPB$json = const {
   '1': 'FunctionInfoPB',
   '2': const [
-    const {
-      '1': 'function_modifiers',
-      '3': 1,
-      '4': 1,
-      '5': 11,
-      '6': '.dart2js_info.proto.FunctionModifiersPB',
-      '10': 'functionModifiers'
-    },
+    const {'1': 'function_modifiers', '3': 1, '4': 1, '5': 11, '6': '.dart2js_info.proto.FunctionModifiersPB', '10': 'functionModifiers'},
     const {'1': 'children_ids', '3': 2, '4': 3, '5': 9, '10': 'childrenIds'},
     const {'1': 'return_type', '3': 3, '4': 1, '5': 9, '10': 'returnType'},
-    const {
-      '1': 'inferred_return_type',
-      '3': 4,
-      '4': 1,
-      '5': 9,
-      '10': 'inferredReturnType'
-    },
-    const {
-      '1': 'parameters',
-      '3': 5,
-      '4': 3,
-      '5': 11,
-      '6': '.dart2js_info.proto.ParameterInfoPB',
-      '10': 'parameters'
-    },
+    const {'1': 'inferred_return_type', '3': 4, '4': 1, '5': 9, '10': 'inferredReturnType'},
+    const {'1': 'parameters', '3': 5, '4': 3, '5': 11, '6': '.dart2js_info.proto.ParameterInfoPB', '10': 'parameters'},
     const {'1': 'side_effects', '3': 6, '4': 1, '5': 9, '10': 'sideEffects'},
     const {'1': 'inlined_count', '3': 7, '4': 1, '5': 5, '10': 'inlinedCount'},
     const {'1': 'code', '3': 8, '4': 1, '5': 9, '10': 'code'},
-    const {
-      '1': 'measurements',
-      '3': 9,
-      '4': 1,
-      '5': 11,
-      '6': '.dart2js_info.proto.MeasurementsPB',
-      '10': 'measurements'
-    },
+    const {'1': 'measurements', '3': 9, '4': 1, '5': 11, '6': '.dart2js_info.proto.MeasurementsPB', '10': 'measurements'},
   ],
 };
 
@@ -411,13 +207,14 @@ const LibraryDeferredImportsPB$json = const {
   '2': const [
     const {'1': 'library_uri', '3': 1, '4': 1, '5': 9, '10': 'libraryUri'},
     const {'1': 'library_name', '3': 2, '4': 1, '5': 9, '10': 'libraryName'},
-    const {
-      '1': 'imports',
-      '3': 3,
-      '4': 3,
-      '5': 11,
-      '6': '.dart2js_info.proto.DeferredImportPB',
-      '10': 'imports'
-    },
+    const {'1': 'imports', '3': 3, '4': 3, '5': 11, '6': '.dart2js_info.proto.DeferredImportPB', '10': 'imports'},
   ],
 };
+
+const DeferredImportInfoPB$json = const {
+  '1': 'DeferredImportInfoPB',
+  '2': const [
+    const {'1': 'required_output_unit_ids', '3': 1, '4': 3, '5': 9, '10': 'requiredOutputUnitIds'},
+  ],
+};
+

--- a/lib/src/proto/info.pbserver.dart
+++ b/lib/src/proto/info.pbserver.dart
@@ -4,3 +4,4 @@
 // ignore_for_file: non_constant_identifier_names,library_prefixes
 
 export 'info.pb.dart';
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart2js_info
-version: 0.5.9
+version: 0.5.10
 description: >
   Libraries and tools to process data produced when running dart2js with
   --dump-info.

--- a/test/hello_world_deferred/hello_world_deferred.js.info.json
+++ b/test/hello_world_deferred/hello_world_deferred.js.info.json
@@ -164,6 +164,7 @@
         "name": "<unnamed>",
         "size": 996,
         "children": [
+          "deferredImport/9990001",
           "function/921486255"
         ],
         "canonicalUri": "file:///usr/local/google/home/lorenvs/git/dart2js_info/test/hello_world_deferred/hello_world_deferred.dart"
@@ -26088,7 +26089,8 @@
       "size": 1353,
       "imports": [
         "deferred_import"
-      ]
+      ],
+      "deferredImports": ["deferredImport/9990001"]
     },
     {
       "id": "outputUnit/669725655",
@@ -26096,6 +26098,16 @@
       "name": "main",
       "size": 156027,
       "imports": []
+    }
+  ],
+  "deferredImports": [
+    {
+      "id": "deferredImport/9990001",
+      "kind": "deferredImport",
+      "name": "deferred_import",
+      "size": 1353,
+      "parent": "library/934372066",
+      "requiredOutputUnits": ["outputUnit/7045321"]
     }
   ],
   "dump_version": 5,

--- a/test/json_to_proto_deferred_test.dart
+++ b/test/json_to_proto_deferred_test.dart
@@ -45,6 +45,21 @@ main() {
       expect(defaultOutputUnit, isNotNull);
       expect(defaultOutputUnit.hasOutputUnitInfo(), isTrue);
       expect(defaultOutputUnit.outputUnitInfo.imports, isEmpty);
+
+      final deferredImportInfos = proto.allInfos
+          .where((info) => info.value.hasDeferredImportInfo())
+          .map((info) => info.value)
+          .toList();
+      expect(deferredImportInfos, hasLength(1));
+      final deferredImportInfo = deferredImportInfos.first;
+      expect(deferredImportInfo.name, "deferred_import");
+      expect(deferredImportInfo.parentId, startsWith("library/"));
+      expect(deferredImportInfo.deferredImportInfo.requiredOutputUnitIds,
+          hasLength(1));
+      final requiredOutputUnitId =
+          deferredImportInfo.deferredImportInfo.requiredOutputUnitIds.first;
+      expect(deferredImportInfo.outputUnitId, isNot(requiredOutputUnitId));
+      expect(infoMap[requiredOutputUnitId].name, isNot("main"));
     });
   });
 }

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -28,5 +28,23 @@ main() {
       expect(program.noSuchMethodEnabled, false);
       expect(program.minified, false);
     });
+
+    test('hello_world_deferred', () {
+      final helloWorldDeferred = new File(
+          'test/hello_world_deferred/hello_world_deferred.js.info.json');
+      final json = jsonDecode(helloWorldDeferred.readAsStringSync());
+      final decoded = new AllInfoJsonCodec().decode(json);
+
+      // There is only one deferred import, which should be from the main output unit
+      // to the second output unit.
+      expect(decoded.outputUnits, hasLength(2));
+      expect(decoded.deferredImports, hasLength(1));
+      final deferredImport = decoded.deferredImports.first;
+      expect(deferredImport.name, "deferred_import");
+      expect(deferredImport.parent, const TypeMatcher<LibraryInfo>());
+      expect(deferredImport.requiredOutputUnits, hasLength(1));
+      final requiredOutputUnit = deferredImport.requiredOutputUnits.first;
+      expect(requiredOutputUnit.name, isNot("main"));
+    });
   });
 }


### PR DESCRIPTION
The main motivator for this change is to be able to generate qualified import names from info files. The current deferredFiles map only contains the local import name, which for applications that re-use the same deferred import alias in many different libraries becomes very hard to reason about. I'm taking a stab at this without a ton of research, but I do believe we can generate this format trivially from dart2js.

One potential shortcoming of this approach is I don't believe its possible to build an entire graph of potential output unit dependencies. I'm using a LibraryInfo as the parent of a DeferredImport, which seems sensible. However, that Library could in theory contain two separate loadLibrary() calls for the same deferred import in two separate functions, which are then compiled into two separate OutputUnits. It would be nice to have a mechanism for building the entire OutputUnit dependency graph, but I'm not sure what the most reasonable way to model this is. I'm not certain how reasonable it would be for dart2js to emit information about loadLibrary() calls, and not just about deferred imports. If it did, we should be able to add an info type whose parent is an output unit, and which references a deferred import.