### PR TITLE
Use a relative path when generating unique IDs for elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.13
+
+* Use a more efficient `Map` implementation for decoding existing info files.
+
+* Use a relative path when generating unique IDs for elements in non-package
+  sources.
+
 ## 0.5.12
 
 * Improved output of `dart2js_info_diff` by sorting the diffs by

--- a/lib/info.dart
+++ b/lib/info.dart
@@ -73,7 +73,7 @@ abstract class BasicInfo implements Info {
         // Instead, use the content of the code.
         _id = (this as ConstantInfo).code.hashCode;
       } else {
-        _id = longName(this, useLibraryUri: true).hashCode;
+        _id = longName(this, useLibraryUri: true, forId: true).hashCode;
       }
       while (!_ids.add(_id)) {
         _id++;

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -66,9 +66,12 @@ String longName(Info info, {bool useLibraryUri: false, bool forId: false}) {
     // assert(!first || segment is LibraryInfo);
     // (today might not be true for for closure classes).
     if (segment is LibraryInfo) {
+      // TODO(kevmoo): Remove this when dart2js can be invoked with an app-root
+      // custom URI
       if (useLibraryUri && forId && segment.uri.isScheme('file')) {
-        var currentBase = Uri.base.toString();
-        var segmentString = segment.uri.toString();
+        assert(Uri.base.isScheme('file'));
+        var currentBase = Uri.base.path;
+        var segmentString = segment.uri.path;
 
         // If longName is being called to calculate an element ID (forId = true)
         // then use a relative path for the longName calculation

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -76,7 +76,7 @@ String longName(Info info, {bool useLibraryUri: false, bool forId: false}) {
         // If longName is being called to calculate an element ID (forId = true)
         // then use a relative path for the longName calculation
         // This allows a more stable ID for cases when files are generated into
-        // per-build temp directories – like with pkg: build
+        // temp directories – e.g. with pkg:build_web_compilers
         if (segmentString.startsWith(currentBase)) {
           segmentString = segmentString.substring(currentBase.length);
         }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -52,7 +52,7 @@ Graph<Info> graphFromInfo(AllInfo info) {
 
 /// Provide a unique long name associated with [info].
 // TODO(sigmund): guarantee that the name is actually unique.
-String longName(Info info, {bool useLibraryUri: false}) {
+String longName(Info info, {bool useLibraryUri: false, bool forId: false}) {
   var infoPath = [];
   while (info != null) {
     infoPath.add(info);
@@ -66,7 +66,22 @@ String longName(Info info, {bool useLibraryUri: false}) {
     // assert(!first || segment is LibraryInfo);
     // (today might not be true for for closure classes).
     if (segment is LibraryInfo) {
-      sb.write(useLibraryUri ? segment.uri : segment.name);
+      if (useLibraryUri && forId && segment.uri.isScheme('file')) {
+        var currentBase = Uri.base.toString();
+        var segmentString = segment.uri.toString();
+
+        // If longName is being called to calculate an element ID (forId = true)
+        // then use a relative path for the longName calculation
+        // This allows a more stable ID for cases when files are generated into
+        // per-build temp directories – like with pkg: build
+        if (segmentString.startsWith(currentBase)) {
+          segmentString = segmentString.substring(currentBase.length);
+        }
+
+        sb.write(segmentString);
+      } else {
+        sb.write(useLibraryUri ? segment.uri : segment.name);
+      }
       sb.write('::');
     } else {
       first = false;


### PR DESCRIPTION
This does not affect the canonical URI for a library, but it does
ensure the IDs for libraries and their members are more stable when
using build systems that rely on temporary directories, like pkg:build

This accomplishes most of the desired behavior from
https://github.com/dart-lang/sdk/commit/7fe8659613bfbf360d57d12327b7521cd869987a

which was reverted in
https://github.com/dart-lang/sdk/commit/2e1c17e5c15766baa8771ad4f29ef188fec52699