### PR TITLE
Split out io from util.dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.16
+
+* Split out IO dependency from `util.dart`, so all other utilities can be used
+  on any platform.
+
 ## 0.5.15
 
 * Add `BasicInfo.resetIds` to free internal cache used for id uniqueness.

--- a/bin/code_deps.dart
+++ b/bin/code_deps.dart
@@ -30,6 +30,7 @@ import 'dart:io';
 
 import 'package:dart2js_info/info.dart';
 import 'package:dart2js_info/src/graph.dart';
+import 'package:dart2js_info/src/io.dart';
 import 'package:dart2js_info/src/util.dart';
 
 main(args) async {

--- a/bin/debug_info.dart
+++ b/bin/debug_info.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 
 import 'package:dart2js_info/info.dart';
 import 'package:dart2js_info/src/graph.dart';
+import 'package:dart2js_info/src/io.dart';
 import 'package:dart2js_info/src/util.dart';
 
 main(args) async {

--- a/bin/deferred_library_check.dart
+++ b/bin/deferred_library_check.dart
@@ -39,7 +39,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:dart2js_info/deferred_library_check.dart';
-import 'package:dart2js_info/src/util.dart';
+import 'package:dart2js_info/src/io.dart';
 import 'package:yaml/yaml.dart';
 
 Future main(List<String> args) async {

--- a/bin/deferred_library_layout.dart
+++ b/bin/deferred_library_layout.dart
@@ -8,7 +8,7 @@ library dart2js_info.bin.deferred_library_size;
 import 'dart:io';
 
 import 'package:dart2js_info/info.dart';
-import 'package:dart2js_info/src/util.dart';
+import 'package:dart2js_info/src/io.dart';
 
 main(args) async {
   AllInfo info = await infoFromFile(args.first);

--- a/bin/deferred_library_size.dart
+++ b/bin/deferred_library_size.dart
@@ -8,7 +8,7 @@ library dart2js_info.bin.deferred_library_size;
 import 'dart:math';
 
 import 'package:dart2js_info/info.dart';
-import 'package:dart2js_info/src/util.dart';
+import 'package:dart2js_info/src/io.dart';
 
 main(args) async {
   // TODO(het): Would be faster to only parse the 'outputUnits' part

--- a/bin/diff.dart
+++ b/bin/diff.dart
@@ -4,6 +4,7 @@
 
 import 'package:dart2js_info/info.dart';
 import 'package:dart2js_info/src/diff.dart';
+import 'package:dart2js_info/src/io.dart';
 import 'package:dart2js_info/src/util.dart';
 
 /// A command-line tool that computes the diff between two info files.

--- a/bin/function_size_analysis.dart
+++ b/bin/function_size_analysis.dart
@@ -10,6 +10,7 @@ import 'dart:math' as math;
 
 import 'package:dart2js_info/info.dart';
 import 'package:dart2js_info/src/graph.dart';
+import 'package:dart2js_info/src/io.dart';
 import 'package:dart2js_info/src/util.dart';
 
 main(args) async {

--- a/bin/info_json_to_proto.dart
+++ b/bin/info_json_to_proto.dart
@@ -8,7 +8,7 @@
 import 'dart:io';
 
 import 'package:dart2js_info/proto_info_codec.dart';
-import 'package:dart2js_info/src/util.dart';
+import 'package:dart2js_info/src/io.dart';
 
 main(args) async {
   if (args.length != 2) {

--- a/bin/library_size_split.dart
+++ b/bin/library_size_split.dart
@@ -63,7 +63,7 @@ import 'dart:io';
 import 'dart:math' show max;
 
 import 'package:dart2js_info/info.dart';
-import 'package:dart2js_info/src/util.dart';
+import 'package:dart2js_info/src/io.dart';
 import 'package:yaml/yaml.dart';
 
 main(args) async {

--- a/bin/live_code_size_analysis.dart
+++ b/bin/live_code_size_analysis.dart
@@ -38,6 +38,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart2js_info/info.dart';
+import 'package:dart2js_info/src/io.dart';
 import 'package:dart2js_info/src/util.dart';
 
 import 'function_size_analysis.dart';

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -1,0 +1,10 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart2js_info/info.dart';
+
+Future<AllInfo> infoFromFile(String fileName) async {
+  var file = await new File(fileName).readAsString();
+  return new AllInfoJsonCodec().decode(jsonDecode(file));
+}

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -4,10 +4,6 @@
 
 library dart2js_info.src.util;
 
-import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:dart2js_info/info.dart';
 
 import 'graph.dart';
@@ -148,9 +144,4 @@ String recursiveDiagnosticString(Measurements measurements, Metric metric) {
 
   helper(metric);
   return sb.toString();
-}
-
-Future<AllInfo> infoFromFile(String fileName) async {
-  var file = await new File(fileName).readAsString();
-  return new AllInfoJsonCodec().decode(jsonDecode(file));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart2js_info
-version: 0.5.15
+version: 0.5.16
 
 description: >
   Libraries and tools to process data produced when running dart2js with


### PR DESCRIPTION
Split out IO dependency from `util.dart`, so all other utilities can be used on any platform.