### PR TITLE
Report library-sizes using the library uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.17
+
+* Make `live_code_size_analysis` print library URIs and not library names.
+
 ## 0.5.16
 
 * Split out IO dependency from `util.dart`, so all other utilities can be used

--- a/bin/function_size_analysis.dart
+++ b/bin/function_size_analysis.dart
@@ -79,7 +79,7 @@ showCodeDistribution(AllInfo info,
 
   if (showLibrarySizes) {
     print(' --- Results per library ---');
-    var totals = {};
+    var totals = <LibraryInfo, int>{};
     var longest = 0;
     reported.forEach((info) {
       var size = info.size;
@@ -87,17 +87,17 @@ showCodeDistribution(AllInfo info,
         info = info.parent;
       }
       if (info == null) return;
-      var name = info.name;
-      totals.putIfAbsent(name, () => 0);
-      totals[name] += size;
-      longest = math.max(longest, name.length);
+      LibraryInfo lib = info;
+      totals.putIfAbsent(lib, () => 0);
+      totals[lib] += size;
+      longest = math.max(longest, '${lib.uri}'.length);
     });
 
     _showLibHeader(longest + 1);
     var reportedByLibrary = totals.keys.toList();
     reportedByLibrary.sort((a, b) => totals[b] - totals[a]);
-    reportedByLibrary.forEach((name) {
-      _showLib(name, totals[name], realTotal, longest + 1);
+    reportedByLibrary.forEach((info) {
+      _showLib('${info.uri}', totals[info], realTotal, longest + 1);
     });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart2js_info
-version: 0.5.16
+version: 0.5.17
 
 description: >
   Libraries and tools to process data produced when running dart2js with


### PR DESCRIPTION
Now that library names are discouraged, some apps have too many entries under "<unnamed>". This switches to use the library URI to report results.