### PR TITLE
Allow all tools to read JSON or binary format

### DIFF
--- a/bin/show_inferred_types.dart
+++ b/bin/show_inferred_types.dart
@@ -5,13 +5,12 @@
 /// Simple script that shows the inferred types of a function.
 library compiler.tool.show_inferred_types;
 
-import 'dart:convert';
 import 'dart:io';
 
-import 'package:dart2js_info/json_info_codec.dart';
 import 'package:dart2js_info/src/util.dart';
+import 'package:dart2js_info/src/io.dart';
 
-main(args) {
+main(args) async {
   if (args.length < 2) {
     var scriptName = Platform.script.pathSegments.last;
     print('usage: dart $scriptName <info.json> <function-name-regex> [-l]');
@@ -21,8 +20,7 @@ main(args) {
 
   var showLongName = args.length > 2 && args[2] == '-l';
 
-  var json = jsonDecode(new File(args[0]).readAsStringSync());
-  var info = new AllInfoJsonCodec().decode(json);
+  var info = await infoFromFile(args[0]);
   var nameRegExp = new RegExp(args[1]);
   matches(e) => nameRegExp.hasMatch(longName(e));
 

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -4,8 +4,13 @@ import 'dart:io';
 
 import 'package:dart2js_info/info.dart';
 import 'package:dart2js_info/json_info_codec.dart';
+import 'package:dart2js_info/binary_serialization.dart' as binary;
 
 Future<AllInfo> infoFromFile(String fileName) async {
-  var file = await new File(fileName).readAsString();
-  return new AllInfoJsonCodec().decode(jsonDecode(file));
+  var file = new File(fileName);
+  if (fileName.endsWith('.json')) {
+    return new AllInfoJsonCodec().decode(jsonDecode(await file.readAsString()));
+  } else {
+    return binary.decode(file.readAsBytesSync());
+  }
 }


### PR DESCRIPTION
Most tools already use the helper method `infoFromFile`, so I just had to move one more tool to use it.