### PR TITLE
Add json binary converters

### DIFF
--- a/bin/binary_to_json.dart
+++ b/bin/binary_to_json.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+import 'dart:convert';
+
+import 'package:dart2js_info/info.dart';
+import 'package:dart2js_info/binary_serialization.dart' as binary;
+import 'package:dart2js_info/json_info_codec.dart';
+
+/// Converts a dump-info file emitted by dart2js in binary format to JSON.
+main(args) async {
+  if (args.length < 1) {
+    print('usage: binary_to_json <input.data> [--compat-mode]'
+        '\n\n'
+        '    By default files are converted to the latest JSON format, but\n'
+        '    passing `--compat-mode` will produce a JSON file that may still\n'
+        '    work in the visualizer tool at: \n'
+        '    https://dart-lang.github.io/dump-info-visualizer/.\n\n'
+        '    Note, however, that files produced in this mode do not contain\n'
+        '    all the data available in the input file.');
+    exit(1);
+  }
+
+  var input = new File(args[0]).readAsBytesSync();
+  bool isBackwardCompatible = args.length > 1 && args.contains('--compat-mode');
+  AllInfo info = binary.decode(input);
+
+  // Fill the text of each code span. The binary form produced by dart2js
+  // produces code spans, but excludes the orignal text
+  info.functions.forEach((f) {
+    f.code.forEach((span) => _fillSpan(span, f.outputUnit));
+  });
+  info.fields.forEach((f) {
+    f.code.forEach((span) => _fillSpan(span, f.outputUnit));
+  });
+  info.constants.forEach((c) {
+    c.code.forEach((span) => _fillSpan(span, c.outputUnit));
+  });
+
+  var json = new AllInfoJsonCodec(isBackwardCompatible: isBackwardCompatible)
+      .encode(info);
+  new File("${args[0]}.json")
+      .writeAsStringSync(const JsonEncoder.withIndent("  ").convert(json));
+}
+
+Map<String, String> _cache = {};
+
+_getContents(OutputUnitInfo unit) => _cache.putIfAbsent(unit.filename, () {
+      var uri = Uri.base.resolve(unit.filename);
+      return new File.fromUri(uri).readAsStringSync();
+    });
+
+_fillSpan(CodeSpan span, OutputUnitInfo unit) {
+  if (span.text == null && span.start != null && span.end != 0) {
+    var contents = _getContents(unit);
+    span.text = contents.substring(span.start, span.end);
+  }
+}

--- a/bin/json_to_binary.dart
+++ b/bin/json_to_binary.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+import 'dart:convert';
+
+import 'package:dart2js_info/info.dart';
+import 'package:dart2js_info/binary_serialization.dart' as binary;
+import 'package:dart2js_info/json_info_codec.dart';
+
+main(args) async {
+  if (args.length < 1) {
+    print('usage: json_to_binary <input.json>');
+    exit(1);
+  }
+
+  var input = new File(args[0]).readAsStringSync();
+  AllInfo info = new AllInfoJsonCodec().decode(jsonDecode(input));
+  var outstream = new File("${args[0]}.data").openWrite();
+  binary.encode(info, outstream);
+  await outstream.done;
+  binary.decode(new File("${args[0]}.data").readAsBytesSync());
+}

--- a/lib/binary_serialization.dart
+++ b/lib/binary_serialization.dart
@@ -206,6 +206,7 @@ class BinaryPrinter implements InfoVisitor<void> {
   void visitOutput(OutputUnitInfo output) {
     sink.writeCached(output, (OutputUnitInfo info) {
       _visitBasicInfo(info);
+      sink.writeStringOrNull(info.filename);
       sink.writeList(info.imports, sink.writeString);
     });
   }
@@ -445,6 +446,7 @@ class BinaryReader {
   OutputUnitInfo readOutput() => source.readCached<OutputUnitInfo>(() {
         OutputUnitInfo info = new OutputUnitInfo.internal();
         _readBasicInfo(info);
+        info.filename = source.readStringOrNull();
         info.imports = source.readList(source.readString);
         return info;
       });

--- a/lib/info.dart
+++ b/lib/info.dart
@@ -203,10 +203,12 @@ class LibraryInfo extends BasicInfo {
 /// program unless the application uses deferred imports, in which case there
 /// would be an additional output unit per deferred chunk.
 class OutputUnitInfo extends BasicInfo {
+  String filename;
+
   /// The deferred imports that will load this output unit.
   List<String> imports = <String>[];
 
-  OutputUnitInfo(String name, int size)
+  OutputUnitInfo(this.filename, String name, int size)
       : super(InfoKind.outputUnit, name, null, size, null);
 
   OutputUnitInfo.internal() : super.internal(InfoKind.outputUnit);

--- a/lib/json_info_codec.dart
+++ b/lib/json_info_codec.dart
@@ -92,6 +92,7 @@ class JsonToAllInfoConverter extends Converter<Map<String, dynamic>, AllInfo> {
   OutputUnitInfo parseOutputUnit(Map json) {
     OutputUnitInfo result = parseId(json['id']);
     result
+      ..filename = json['filename']
       ..name = json['name']
       ..size = json['size'];
     result.imports
@@ -252,6 +253,7 @@ class JsonToAllInfoConverter extends Converter<Map<String, dynamic>, AllInfo> {
           (json['parameters'] as List).map((p) => parseParameter(p)).toList()
       ..code = parseCode(json['code'])
       ..sideEffects = json['sideEffects']
+      ..inlinedCount = json['inlinedCount']
       ..modifiers =
           parseModifiers(new Map<String, bool>.from(json['modifiers']))
       ..closures = (json['children'] as List)
@@ -583,8 +585,9 @@ class AllInfoToJsonConverter extends Converter<AllInfo, Map>
 
   visitTypedef(TypedefInfo info) => _visitBasicInfo(info)..['type'] = info.type;
 
-  visitOutput(OutputUnitInfo info) =>
-      _visitBasicInfo(info)..['imports'] = info.imports;
+  visitOutput(OutputUnitInfo info) => _visitBasicInfo(info)
+    ..['filename'] = info.filename
+    ..['imports'] = info.imports;
 
   Object _serializeCode(List<CodeSpan> code) {
     if (isBackwardCompatible) {


### PR DESCRIPTION
We add `filename` to `OutputUnitInfo` so we can fill-in the source text corresponding to a source-span. We do this for binary-2-json conversions by default.