### PR TITLE
Refactor flags for the 'convert' command

### DIFF
--- a/bin/convert.dart
+++ b/bin/convert.dart
@@ -12,11 +12,27 @@ import 'usage_exception.dart';
 /// This tool reports how code is divided among deferred chunks.
 class ConvertCommand extends Command<void> with PrintUsageException {
   final String name = "convert";
-  final String description = "Convert between the binary and JSON info format.";
+  final String description = "Convert between info formats.";
 
   ConvertCommand() {
-    addSubcommand(new ToJsonCommand());
-    addSubcommand(new ToBinaryCommand());
-    addSubcommand(new ToProtoCommand());
+    _addSubcommand(new ToJsonCommand());
+    _addSubcommand(new ToBinaryCommand());
+    _addSubcommand(new ToProtoCommand());
+  }
+
+  _addSubcommand(Command<void> command) {
+    addSubcommand(command);
+    command.argParser
+      ..addOption('out',
+          abbr: 'o',
+          help: 'Output file '
+              '(to_json defauts to <input>.json, to_binary defaults to\n'
+              '<input>.data, and to_proto defaults to <input>.pb)')
+      ..addFlag('inject-text',
+          negatable: false,
+          help: 'Whether to inject output code snippets.\n\n'
+              'By default dart2js produces code spans, but excludes the text. This\n'
+              'option can be used to embed the text directly in the output.\n'
+              'Note: this requires access to dart2js output files.\n');
   }
 }

--- a/bin/to_binary.dart
+++ b/bin/to_binary.dart
@@ -10,17 +10,13 @@ import 'package:dart2js_info/info.dart';
 import 'package:dart2js_info/binary_serialization.dart' as binary;
 import 'package:dart2js_info/src/io.dart';
 
+import 'inject_text.dart';
 import 'usage_exception.dart';
 
 /// Converts a dump-info file emitted by dart2js in JSON to binary format.
 class ToBinaryCommand extends Command<void> with PrintUsageException {
   final String name = "to_binary";
   final String description = "Convert any info file to binary format.";
-
-  ToBinaryCommand() {
-    argParser.addOption('out',
-        abbr: 'o', help: 'Output file (defauts to <input>.data)');
-  }
 
   void run() async {
     if (argResults.rest.length < 1) {
@@ -30,6 +26,7 @@ class ToBinaryCommand extends Command<void> with PrintUsageException {
 
     String filename = argResults.rest[0];
     AllInfo info = await infoFromFile(filename);
+    if (argResults['inject-text']) injectText(info);
     String outputFilename = argResults['out'] ?? '$filename.data';
     var outstream = new File(outputFilename).openWrite();
     binary.encode(info, outstream);

--- a/bin/to_json.dart
+++ b/bin/to_json.dart
@@ -20,16 +20,6 @@ class ToJsonCommand extends Command<void> with PrintUsageException {
   final String description = "Convert any info file to JSON format.";
 
   ToJsonCommand() {
-    argParser.addOption('out',
-        abbr: 'o', help: 'Output file (defauts to <input>.json)');
-
-    argParser.addFlag('inject-text',
-        negatable: false,
-        help: 'Whether to inject output code snippets.\n\n'
-            'By default dart2js produces code spans, but excludes the text. This\n'
-            'option can be used to embed the text directly in the output JSON.\n'
-            'This is implied by `--compat-mode`.');
-
     argParser.addFlag('compat-mode',
         negatable: false,
         help: 'Whether to generate an older version of the JSON format.\n\n'
@@ -37,8 +27,9 @@ class ToJsonCommand extends Command<void> with PrintUsageException {
             'passing `--compat-mode` will produce a JSON file that may still\n'
             'work in the visualizer tool at:\n'
             'https://dart-lang.github.io/dump-info-visualizer/.\n\n'
-            'Note, however, that files produced in this mode do not contain\n'
-            'all the data available in the input file.');
+            'This option enables `--inject-text` as well, but note that\n'
+            'files produced in this mode do not contain all the data\n'
+            'available in the input file.');
   }
 
   void run() async {

--- a/bin/to_proto.dart
+++ b/bin/to_proto.dart
@@ -12,17 +12,13 @@ import 'package:args/command_runner.dart';
 import 'package:dart2js_info/proto_info_codec.dart';
 import 'package:dart2js_info/src/io.dart';
 
+import 'inject_text.dart';
 import 'usage_exception.dart';
 
 /// Converts a dump-info file emitted by dart2js to the proto format
 class ToProtoCommand extends Command<void> with PrintUsageException {
   final String name = "to_proto";
   final String description = "Convert any info file to proto format.";
-
-  ToProtoCommand() {
-    argParser.addOption('out',
-        abbr: 'o', help: 'Output file (defauts to <input>.pb)');
-  }
 
   void run() async {
     if (argResults.rest.length < 1) {
@@ -32,6 +28,7 @@ class ToProtoCommand extends Command<void> with PrintUsageException {
 
     String filename = argResults.rest[0];
     final info = await infoFromFile(filename);
+    if (argResults['inject-text']) injectText(info);
     final proto = new AllInfoProtoCodec().encode(info);
     String outputFilename = argResults['out'] ?? '$filename.pb';
     final outputFile = new File(outputFilename);


### PR DESCRIPTION
All conversions use the same -o and --inject-text flags.