### PR TITLE
Use unqualified enum strings when generating serialized ids in the proto codec

### DIFF
--- a/lib/proto_info_codec.dart
+++ b/lib/proto_info_codec.dart
@@ -310,5 +310,5 @@ class Id {
 
   Id(this.kind, this.id);
 
-  String get serializedId => '$kind/$id';
+  String get serializedId => '${kindToString(kind)}/$id';
 }

--- a/test/json_to_proto_test.dart
+++ b/test/json_to_proto_test.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dart2js_info/info.dart';
 import 'package:dart2js_info/json_info_codec.dart';
 import 'package:dart2js_info/proto_info_codec.dart';
 import 'package:test/test.dart';
@@ -27,6 +28,47 @@ main() {
           new Duration(milliseconds: 0).inMicroseconds);
       expect(proto.program.noSuchMethodEnabled, isFalse);
       expect(proto.program.minified, isFalse);
+    });
+
+    test('has proper id format', () {
+      final helloWorld = new File('test/hello_world/hello_world.js.info.json');
+      final json = jsonDecode(helloWorld.readAsStringSync());
+      final decoded = new AllInfoJsonCodec().decode(json);
+      final proto = new AllInfoProtoCodec().encode(decoded);
+
+      final expectedPrefixes = <InfoKind, String>{};
+      for (final kind in InfoKind.values) {
+        expectedPrefixes[kind] = kindToString(kind) + '/';
+      }
+
+      for (final info in proto.allInfos) {
+        final value = info.value;
+        if (value.hasLibraryInfo()) {
+          expect(value.serializedId,
+              startsWith(expectedPrefixes[InfoKind.library]));
+        } else if (value.hasClassInfo()) {
+          expect(
+              value.serializedId, startsWith(expectedPrefixes[InfoKind.clazz]));
+        } else if (value.hasFunctionInfo()) {
+          expect(value.serializedId,
+              startsWith(expectedPrefixes[InfoKind.function]));
+        } else if (value.hasFieldInfo()) {
+          expect(
+              value.serializedId, startsWith(expectedPrefixes[InfoKind.field]));
+        } else if (value.hasConstantInfo()) {
+          expect(value.serializedId,
+              startsWith(expectedPrefixes[InfoKind.constant]));
+        } else if (value.hasOutputUnitInfo()) {
+          expect(value.serializedId,
+              startsWith(expectedPrefixes[InfoKind.outputUnit]));
+        } else if (value.hasTypedefInfo()) {
+          expect(value.serializedId,
+              startsWith(expectedPrefixes[InfoKind.typedef]));
+        } else if (value.hasClosureInfo()) {
+          expect(value.serializedId,
+              startsWith(expectedPrefixes[InfoKind.closure]));
+        }
+      }
     });
   });
 }


### PR DESCRIPTION
Recent changes have resulted in serialized ids that look like "InfoKind.outputUnit/1" rather than just "outputUnit/1".

