### PR TITLE
Update protobuf dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.6.2
 
 * Update `protobuf` dependency.
+* Set min SDK to `2.3.0`, as generated code contains this version.
 
 ## 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2
+
+* Update `protobuf` dependency.
+
 ## 0.6.1
 
 * Move binary subcommands under src folder. Otherwise, `pub global activate`

--- a/lib/proto_info_codec.dart
+++ b/lib/proto_info_codec.dart
@@ -246,13 +246,11 @@ class AllInfoToProtoConverter extends Converter<AllInfo, AllInfoPB> {
     return result;
   }
 
-  Iterable<AllInfoPB_AllInfosEntry> _convertToAllInfosEntries<T extends Info>(
+  Iterable<MapEntry<String, InfoPB>> _convertToAllInfosEntries<T extends Info>(
       Iterable<T> infos) sync* {
     for (final info in infos) {
       final infoProto = _convertToInfoPB(info);
-      final entry = new AllInfoPB_AllInfosEntry()
-        ..key = infoProto.serializedId
-        ..value = infoProto;
+      final entry = MapEntry<String, InfoPB>(infoProto.serializedId, infoProto);
       yield entry;
     }
   }
@@ -277,14 +275,14 @@ class AllInfoToProtoConverter extends Converter<AllInfo, AllInfoPB> {
     final proto = new AllInfoPB()
       ..program = _convertToProgramInfoPB(info.program);
 
-    proto.allInfos.addAll(_convertToAllInfosEntries(info.libraries));
-    proto.allInfos.addAll(_convertToAllInfosEntries(info.classes));
-    proto.allInfos.addAll(_convertToAllInfosEntries(info.functions));
-    proto.allInfos.addAll(_convertToAllInfosEntries(info.fields));
-    proto.allInfos.addAll(_convertToAllInfosEntries(info.constants));
-    proto.allInfos.addAll(_convertToAllInfosEntries(info.outputUnits));
-    proto.allInfos.addAll(_convertToAllInfosEntries(info.typedefs));
-    proto.allInfos.addAll(_convertToAllInfosEntries(info.closures));
+    proto.allInfos.addEntries(_convertToAllInfosEntries(info.libraries));
+    proto.allInfos.addEntries(_convertToAllInfosEntries(info.classes));
+    proto.allInfos.addEntries(_convertToAllInfosEntries(info.functions));
+    proto.allInfos.addEntries(_convertToAllInfosEntries(info.fields));
+    proto.allInfos.addEntries(_convertToAllInfosEntries(info.constants));
+    proto.allInfos.addEntries(_convertToAllInfosEntries(info.outputUnits));
+    proto.allInfos.addEntries(_convertToAllInfosEntries(info.typedefs));
+    proto.allInfos.addEntries(_convertToAllInfosEntries(info.closures));
 
     info.deferredFiles?.forEach((libraryUri, fields) {
       proto.deferredImports

--- a/lib/src/proto/info.pb.dart
+++ b/lib/src/proto/info.pb.dart
@@ -1,330 +1,407 @@
 ///
 //  Generated code. Do not modify.
 //  source: info.proto
-///
-// ignore_for_file: non_constant_identifier_names,library_prefixes,unused_import
+//
+// @dart = 2.3
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
 
-// ignore: UNUSED_SHOWN_NAME
-import 'dart:core' show int, bool, double, String, List, override;
+import 'dart:core' as $core;
 
-import 'package:fixnum/fixnum.dart';
+import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class DependencyInfoPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('DependencyInfoPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('DependencyInfoPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
     ..aOS(1, 'targetId')
     ..aOS(2, 'mask')
     ..hasRequiredFields = false;
 
-  DependencyInfoPB() : super();
-  DependencyInfoPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  DependencyInfoPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  DependencyInfoPB clone() => new DependencyInfoPB()..mergeFromMessage(this);
+  DependencyInfoPB._() : super();
+  factory DependencyInfoPB() => create();
+  factory DependencyInfoPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory DependencyInfoPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  DependencyInfoPB clone() => DependencyInfoPB()..mergeFromMessage(this);
   DependencyInfoPB copyWith(void Function(DependencyInfoPB) updates) =>
       super.copyWith((message) => updates(message as DependencyInfoPB));
   $pb.BuilderInfo get info_ => _i;
-  static DependencyInfoPB create() => new DependencyInfoPB();
+  @$core.pragma('dart2js:noInline')
+  static DependencyInfoPB create() => DependencyInfoPB._();
+  DependencyInfoPB createEmptyInstance() => create();
   static $pb.PbList<DependencyInfoPB> createRepeated() =>
-      new $pb.PbList<DependencyInfoPB>();
-  static DependencyInfoPB getDefault() =>
-      _defaultInstance ??= create()..freeze();
+      $pb.PbList<DependencyInfoPB>();
+  @$core.pragma('dart2js:noInline')
+  static DependencyInfoPB getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<DependencyInfoPB>(create);
   static DependencyInfoPB _defaultInstance;
-  static void $checkItem(DependencyInfoPB v) {
-    if (v is! DependencyInfoPB) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
-  String get targetId => $_getS(0, '');
-  set targetId(String v) {
+  @$pb.TagNumber(1)
+  $core.String get targetId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set targetId($core.String v) {
     $_setString(0, v);
   }
 
-  bool hasTargetId() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasTargetId() => $_has(0);
+  @$pb.TagNumber(1)
   void clearTargetId() => clearField(1);
 
-  String get mask => $_getS(1, '');
-  set mask(String v) {
+  @$pb.TagNumber(2)
+  $core.String get mask => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set mask($core.String v) {
     $_setString(1, v);
   }
 
-  bool hasMask() => $_has(1);
+  @$pb.TagNumber(2)
+  $core.bool hasMask() => $_has(1);
+  @$pb.TagNumber(2)
   void clearMask() => clearField(2);
 }
 
-class AllInfoPB_AllInfosEntry extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo(
-      'AllInfoPB.AllInfosEntry',
-      package: const $pb.PackageName('dart2js_info.proto'))
-    ..aOS(1, 'key')
-    ..a<InfoPB>(
-        2, 'value', $pb.PbFieldType.OM, InfoPB.getDefault, InfoPB.create)
-    ..hasRequiredFields = false;
-
-  AllInfoPB_AllInfosEntry() : super();
-  AllInfoPB_AllInfosEntry.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  AllInfoPB_AllInfosEntry.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  AllInfoPB_AllInfosEntry clone() =>
-      new AllInfoPB_AllInfosEntry()..mergeFromMessage(this);
-  AllInfoPB_AllInfosEntry copyWith(
-          void Function(AllInfoPB_AllInfosEntry) updates) =>
-      super.copyWith((message) => updates(message as AllInfoPB_AllInfosEntry));
-  $pb.BuilderInfo get info_ => _i;
-  static AllInfoPB_AllInfosEntry create() => new AllInfoPB_AllInfosEntry();
-  static $pb.PbList<AllInfoPB_AllInfosEntry> createRepeated() =>
-      new $pb.PbList<AllInfoPB_AllInfosEntry>();
-  static AllInfoPB_AllInfosEntry getDefault() =>
-      _defaultInstance ??= create()..freeze();
-  static AllInfoPB_AllInfosEntry _defaultInstance;
-  static void $checkItem(AllInfoPB_AllInfosEntry v) {
-    if (v is! AllInfoPB_AllInfosEntry)
-      $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
-
-  String get key => $_getS(0, '');
-  set key(String v) {
-    $_setString(0, v);
-  }
-
-  bool hasKey() => $_has(0);
-  void clearKey() => clearField(1);
-
-  InfoPB get value => $_getN(1);
-  set value(InfoPB v) {
-    setField(2, v);
-  }
-
-  bool hasValue() => $_has(1);
-  void clearValue() => clearField(2);
-}
-
 class AllInfoPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('AllInfoPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
-    ..a<ProgramInfoPB>(1, 'program', $pb.PbFieldType.OM,
-        ProgramInfoPB.getDefault, ProgramInfoPB.create)
-    ..pp<AllInfoPB_AllInfosEntry>(2, 'allInfos', $pb.PbFieldType.PM,
-        AllInfoPB_AllInfosEntry.$checkItem, AllInfoPB_AllInfosEntry.create)
-    ..pp<LibraryDeferredImportsPB>(3, 'deferredImports', $pb.PbFieldType.PM,
-        LibraryDeferredImportsPB.$checkItem, LibraryDeferredImportsPB.create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('AllInfoPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
+    ..aOM<ProgramInfoPB>(1, 'program', subBuilder: ProgramInfoPB.create)
+    ..m<$core.String, InfoPB>(2, 'allInfos',
+        entryClassName: 'AllInfoPB.AllInfosEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OM,
+        valueCreator: InfoPB.create,
+        packageName: const $pb.PackageName('dart2js_info.proto'))
+    ..pc<LibraryDeferredImportsPB>(3, 'deferredImports', $pb.PbFieldType.PM,
+        subBuilder: LibraryDeferredImportsPB.create)
     ..hasRequiredFields = false;
 
-  AllInfoPB() : super();
-  AllInfoPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  AllInfoPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  AllInfoPB clone() => new AllInfoPB()..mergeFromMessage(this);
+  AllInfoPB._() : super();
+  factory AllInfoPB() => create();
+  factory AllInfoPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AllInfoPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  AllInfoPB clone() => AllInfoPB()..mergeFromMessage(this);
   AllInfoPB copyWith(void Function(AllInfoPB) updates) =>
       super.copyWith((message) => updates(message as AllInfoPB));
   $pb.BuilderInfo get info_ => _i;
-  static AllInfoPB create() => new AllInfoPB();
-  static $pb.PbList<AllInfoPB> createRepeated() => new $pb.PbList<AllInfoPB>();
-  static AllInfoPB getDefault() => _defaultInstance ??= create()..freeze();
+  @$core.pragma('dart2js:noInline')
+  static AllInfoPB create() => AllInfoPB._();
+  AllInfoPB createEmptyInstance() => create();
+  static $pb.PbList<AllInfoPB> createRepeated() => $pb.PbList<AllInfoPB>();
+  @$core.pragma('dart2js:noInline')
+  static AllInfoPB getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AllInfoPB>(create);
   static AllInfoPB _defaultInstance;
-  static void $checkItem(AllInfoPB v) {
-    if (v is! AllInfoPB) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
+  @$pb.TagNumber(1)
   ProgramInfoPB get program => $_getN(0);
+  @$pb.TagNumber(1)
   set program(ProgramInfoPB v) {
     setField(1, v);
   }
 
-  bool hasProgram() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasProgram() => $_has(0);
+  @$pb.TagNumber(1)
   void clearProgram() => clearField(1);
+  @$pb.TagNumber(1)
+  ProgramInfoPB ensureProgram() => $_ensure(0);
 
-  List<AllInfoPB_AllInfosEntry> get allInfos => $_getList(1);
+  @$pb.TagNumber(2)
+  $core.Map<$core.String, InfoPB> get allInfos => $_getMap(1);
 
-  List<LibraryDeferredImportsPB> get deferredImports => $_getList(2);
+  @$pb.TagNumber(3)
+  $core.List<LibraryDeferredImportsPB> get deferredImports => $_getList(2);
+}
+
+enum InfoPB_Concrete {
+  libraryInfo,
+  classInfo,
+  functionInfo,
+  fieldInfo,
+  constantInfo,
+  outputUnitInfo,
+  typedefInfo,
+  closureInfo,
+  notSet
 }
 
 class InfoPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('InfoPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
+  static const $core.Map<$core.int, InfoPB_Concrete> _InfoPB_ConcreteByTag = {
+    100: InfoPB_Concrete.libraryInfo,
+    101: InfoPB_Concrete.classInfo,
+    102: InfoPB_Concrete.functionInfo,
+    103: InfoPB_Concrete.fieldInfo,
+    104: InfoPB_Concrete.constantInfo,
+    105: InfoPB_Concrete.outputUnitInfo,
+    106: InfoPB_Concrete.typedefInfo,
+    107: InfoPB_Concrete.closureInfo,
+    0: InfoPB_Concrete.notSet
+  };
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('InfoPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
+    ..oo(0, [100, 101, 102, 103, 104, 105, 106, 107])
     ..aOS(1, 'name')
-    ..a<int>(2, 'id', $pb.PbFieldType.O3)
+    ..a<$core.int>(2, 'id', $pb.PbFieldType.O3)
     ..aOS(3, 'serializedId')
     ..aOS(4, 'coverageId')
-    ..a<int>(5, 'size', $pb.PbFieldType.O3)
+    ..a<$core.int>(5, 'size', $pb.PbFieldType.O3)
     ..aOS(6, 'parentId')
-    ..pp<DependencyInfoPB>(7, 'uses', $pb.PbFieldType.PM,
-        DependencyInfoPB.$checkItem, DependencyInfoPB.create)
+    ..pc<DependencyInfoPB>(7, 'uses', $pb.PbFieldType.PM,
+        subBuilder: DependencyInfoPB.create)
     ..aOS(8, 'outputUnitId')
-    ..a<LibraryInfoPB>(100, 'libraryInfo', $pb.PbFieldType.OM,
-        LibraryInfoPB.getDefault, LibraryInfoPB.create)
-    ..a<ClassInfoPB>(101, 'classInfo', $pb.PbFieldType.OM,
-        ClassInfoPB.getDefault, ClassInfoPB.create)
-    ..a<FunctionInfoPB>(102, 'functionInfo', $pb.PbFieldType.OM,
-        FunctionInfoPB.getDefault, FunctionInfoPB.create)
-    ..a<FieldInfoPB>(103, 'fieldInfo', $pb.PbFieldType.OM,
-        FieldInfoPB.getDefault, FieldInfoPB.create)
-    ..a<ConstantInfoPB>(104, 'constantInfo', $pb.PbFieldType.OM,
-        ConstantInfoPB.getDefault, ConstantInfoPB.create)
-    ..a<OutputUnitInfoPB>(105, 'outputUnitInfo', $pb.PbFieldType.OM,
-        OutputUnitInfoPB.getDefault, OutputUnitInfoPB.create)
-    ..a<TypedefInfoPB>(106, 'typedefInfo', $pb.PbFieldType.OM,
-        TypedefInfoPB.getDefault, TypedefInfoPB.create)
-    ..a<ClosureInfoPB>(107, 'closureInfo', $pb.PbFieldType.OM,
-        ClosureInfoPB.getDefault, ClosureInfoPB.create)
+    ..aOM<LibraryInfoPB>(100, 'libraryInfo', subBuilder: LibraryInfoPB.create)
+    ..aOM<ClassInfoPB>(101, 'classInfo', subBuilder: ClassInfoPB.create)
+    ..aOM<FunctionInfoPB>(102, 'functionInfo',
+        subBuilder: FunctionInfoPB.create)
+    ..aOM<FieldInfoPB>(103, 'fieldInfo', subBuilder: FieldInfoPB.create)
+    ..aOM<ConstantInfoPB>(104, 'constantInfo',
+        subBuilder: ConstantInfoPB.create)
+    ..aOM<OutputUnitInfoPB>(105, 'outputUnitInfo',
+        subBuilder: OutputUnitInfoPB.create)
+    ..aOM<TypedefInfoPB>(106, 'typedefInfo', subBuilder: TypedefInfoPB.create)
+    ..aOM<ClosureInfoPB>(107, 'closureInfo', subBuilder: ClosureInfoPB.create)
     ..hasRequiredFields = false;
 
-  InfoPB() : super();
-  InfoPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  InfoPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  InfoPB clone() => new InfoPB()..mergeFromMessage(this);
+  InfoPB._() : super();
+  factory InfoPB() => create();
+  factory InfoPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory InfoPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  InfoPB clone() => InfoPB()..mergeFromMessage(this);
   InfoPB copyWith(void Function(InfoPB) updates) =>
       super.copyWith((message) => updates(message as InfoPB));
   $pb.BuilderInfo get info_ => _i;
-  static InfoPB create() => new InfoPB();
-  static $pb.PbList<InfoPB> createRepeated() => new $pb.PbList<InfoPB>();
-  static InfoPB getDefault() => _defaultInstance ??= create()..freeze();
+  @$core.pragma('dart2js:noInline')
+  static InfoPB create() => InfoPB._();
+  InfoPB createEmptyInstance() => create();
+  static $pb.PbList<InfoPB> createRepeated() => $pb.PbList<InfoPB>();
+  @$core.pragma('dart2js:noInline')
+  static InfoPB getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InfoPB>(create);
   static InfoPB _defaultInstance;
-  static void $checkItem(InfoPB v) {
-    if (v is! InfoPB) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
-  String get name => $_getS(0, '');
-  set name(String v) {
+  InfoPB_Concrete whichConcrete() => _InfoPB_ConcreteByTag[$_whichOneof(0)];
+  void clearConcrete() => clearField($_whichOneof(0));
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) {
     $_setString(0, v);
   }
 
-  bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
   void clearName() => clearField(1);
 
-  int get id => $_get(1, 0);
-  set id(int v) {
+  @$pb.TagNumber(2)
+  $core.int get id => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set id($core.int v) {
     $_setSignedInt32(1, v);
   }
 
-  bool hasId() => $_has(1);
+  @$pb.TagNumber(2)
+  $core.bool hasId() => $_has(1);
+  @$pb.TagNumber(2)
   void clearId() => clearField(2);
 
-  String get serializedId => $_getS(2, '');
-  set serializedId(String v) {
+  @$pb.TagNumber(3)
+  $core.String get serializedId => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set serializedId($core.String v) {
     $_setString(2, v);
   }
 
-  bool hasSerializedId() => $_has(2);
+  @$pb.TagNumber(3)
+  $core.bool hasSerializedId() => $_has(2);
+  @$pb.TagNumber(3)
   void clearSerializedId() => clearField(3);
 
-  String get coverageId => $_getS(3, '');
-  set coverageId(String v) {
+  @$pb.TagNumber(4)
+  $core.String get coverageId => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set coverageId($core.String v) {
     $_setString(3, v);
   }
 
-  bool hasCoverageId() => $_has(3);
+  @$pb.TagNumber(4)
+  $core.bool hasCoverageId() => $_has(3);
+  @$pb.TagNumber(4)
   void clearCoverageId() => clearField(4);
 
-  int get size => $_get(4, 0);
-  set size(int v) {
+  @$pb.TagNumber(5)
+  $core.int get size => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set size($core.int v) {
     $_setSignedInt32(4, v);
   }
 
-  bool hasSize() => $_has(4);
+  @$pb.TagNumber(5)
+  $core.bool hasSize() => $_has(4);
+  @$pb.TagNumber(5)
   void clearSize() => clearField(5);
 
-  String get parentId => $_getS(5, '');
-  set parentId(String v) {
+  @$pb.TagNumber(6)
+  $core.String get parentId => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set parentId($core.String v) {
     $_setString(5, v);
   }
 
-  bool hasParentId() => $_has(5);
+  @$pb.TagNumber(6)
+  $core.bool hasParentId() => $_has(5);
+  @$pb.TagNumber(6)
   void clearParentId() => clearField(6);
 
-  List<DependencyInfoPB> get uses => $_getList(6);
+  @$pb.TagNumber(7)
+  $core.List<DependencyInfoPB> get uses => $_getList(6);
 
-  String get outputUnitId => $_getS(7, '');
-  set outputUnitId(String v) {
+  @$pb.TagNumber(8)
+  $core.String get outputUnitId => $_getSZ(7);
+  @$pb.TagNumber(8)
+  set outputUnitId($core.String v) {
     $_setString(7, v);
   }
 
-  bool hasOutputUnitId() => $_has(7);
+  @$pb.TagNumber(8)
+  $core.bool hasOutputUnitId() => $_has(7);
+  @$pb.TagNumber(8)
   void clearOutputUnitId() => clearField(8);
 
+  @$pb.TagNumber(100)
   LibraryInfoPB get libraryInfo => $_getN(8);
+  @$pb.TagNumber(100)
   set libraryInfo(LibraryInfoPB v) {
     setField(100, v);
   }
 
-  bool hasLibraryInfo() => $_has(8);
+  @$pb.TagNumber(100)
+  $core.bool hasLibraryInfo() => $_has(8);
+  @$pb.TagNumber(100)
   void clearLibraryInfo() => clearField(100);
+  @$pb.TagNumber(100)
+  LibraryInfoPB ensureLibraryInfo() => $_ensure(8);
 
+  @$pb.TagNumber(101)
   ClassInfoPB get classInfo => $_getN(9);
+  @$pb.TagNumber(101)
   set classInfo(ClassInfoPB v) {
     setField(101, v);
   }
 
-  bool hasClassInfo() => $_has(9);
+  @$pb.TagNumber(101)
+  $core.bool hasClassInfo() => $_has(9);
+  @$pb.TagNumber(101)
   void clearClassInfo() => clearField(101);
+  @$pb.TagNumber(101)
+  ClassInfoPB ensureClassInfo() => $_ensure(9);
 
+  @$pb.TagNumber(102)
   FunctionInfoPB get functionInfo => $_getN(10);
+  @$pb.TagNumber(102)
   set functionInfo(FunctionInfoPB v) {
     setField(102, v);
   }
 
-  bool hasFunctionInfo() => $_has(10);
+  @$pb.TagNumber(102)
+  $core.bool hasFunctionInfo() => $_has(10);
+  @$pb.TagNumber(102)
   void clearFunctionInfo() => clearField(102);
+  @$pb.TagNumber(102)
+  FunctionInfoPB ensureFunctionInfo() => $_ensure(10);
 
+  @$pb.TagNumber(103)
   FieldInfoPB get fieldInfo => $_getN(11);
+  @$pb.TagNumber(103)
   set fieldInfo(FieldInfoPB v) {
     setField(103, v);
   }
 
-  bool hasFieldInfo() => $_has(11);
+  @$pb.TagNumber(103)
+  $core.bool hasFieldInfo() => $_has(11);
+  @$pb.TagNumber(103)
   void clearFieldInfo() => clearField(103);
+  @$pb.TagNumber(103)
+  FieldInfoPB ensureFieldInfo() => $_ensure(11);
 
+  @$pb.TagNumber(104)
   ConstantInfoPB get constantInfo => $_getN(12);
+  @$pb.TagNumber(104)
   set constantInfo(ConstantInfoPB v) {
     setField(104, v);
   }
 
-  bool hasConstantInfo() => $_has(12);
+  @$pb.TagNumber(104)
+  $core.bool hasConstantInfo() => $_has(12);
+  @$pb.TagNumber(104)
   void clearConstantInfo() => clearField(104);
+  @$pb.TagNumber(104)
+  ConstantInfoPB ensureConstantInfo() => $_ensure(12);
 
+  @$pb.TagNumber(105)
   OutputUnitInfoPB get outputUnitInfo => $_getN(13);
+  @$pb.TagNumber(105)
   set outputUnitInfo(OutputUnitInfoPB v) {
     setField(105, v);
   }
 
-  bool hasOutputUnitInfo() => $_has(13);
+  @$pb.TagNumber(105)
+  $core.bool hasOutputUnitInfo() => $_has(13);
+  @$pb.TagNumber(105)
   void clearOutputUnitInfo() => clearField(105);
+  @$pb.TagNumber(105)
+  OutputUnitInfoPB ensureOutputUnitInfo() => $_ensure(13);
 
+  @$pb.TagNumber(106)
   TypedefInfoPB get typedefInfo => $_getN(14);
+  @$pb.TagNumber(106)
   set typedefInfo(TypedefInfoPB v) {
     setField(106, v);
   }
 
-  bool hasTypedefInfo() => $_has(14);
+  @$pb.TagNumber(106)
+  $core.bool hasTypedefInfo() => $_has(14);
+  @$pb.TagNumber(106)
   void clearTypedefInfo() => clearField(106);
+  @$pb.TagNumber(106)
+  TypedefInfoPB ensureTypedefInfo() => $_ensure(14);
 
+  @$pb.TagNumber(107)
   ClosureInfoPB get closureInfo => $_getN(15);
+  @$pb.TagNumber(107)
   set closureInfo(ClosureInfoPB v) {
     setField(107, v);
   }
 
-  bool hasClosureInfo() => $_has(15);
+  @$pb.TagNumber(107)
+  $core.bool hasClosureInfo() => $_has(15);
+  @$pb.TagNumber(107)
   void clearClosureInfo() => clearField(107);
+  @$pb.TagNumber(107)
+  ClosureInfoPB ensureClosureInfo() => $_ensure(15);
 }
 
 class ProgramInfoPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('ProgramInfoPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ProgramInfoPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
     ..aOS(1, 'entrypointId')
-    ..a<int>(2, 'size', $pb.PbFieldType.O3)
+    ..a<$core.int>(2, 'size', $pb.PbFieldType.O3)
     ..aOS(3, 'dart2jsVersion')
     ..aInt64(4, 'compilationMoment')
     ..aInt64(5, 'compilationDuration')
@@ -338,275 +415,355 @@ class ProgramInfoPB extends $pb.GeneratedMessage {
     ..aOB(13, 'minified')
     ..hasRequiredFields = false;
 
-  ProgramInfoPB() : super();
-  ProgramInfoPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  ProgramInfoPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  ProgramInfoPB clone() => new ProgramInfoPB()..mergeFromMessage(this);
+  ProgramInfoPB._() : super();
+  factory ProgramInfoPB() => create();
+  factory ProgramInfoPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ProgramInfoPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  ProgramInfoPB clone() => ProgramInfoPB()..mergeFromMessage(this);
   ProgramInfoPB copyWith(void Function(ProgramInfoPB) updates) =>
       super.copyWith((message) => updates(message as ProgramInfoPB));
   $pb.BuilderInfo get info_ => _i;
-  static ProgramInfoPB create() => new ProgramInfoPB();
+  @$core.pragma('dart2js:noInline')
+  static ProgramInfoPB create() => ProgramInfoPB._();
+  ProgramInfoPB createEmptyInstance() => create();
   static $pb.PbList<ProgramInfoPB> createRepeated() =>
-      new $pb.PbList<ProgramInfoPB>();
-  static ProgramInfoPB getDefault() => _defaultInstance ??= create()..freeze();
+      $pb.PbList<ProgramInfoPB>();
+  @$core.pragma('dart2js:noInline')
+  static ProgramInfoPB getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ProgramInfoPB>(create);
   static ProgramInfoPB _defaultInstance;
-  static void $checkItem(ProgramInfoPB v) {
-    if (v is! ProgramInfoPB) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
-  String get entrypointId => $_getS(0, '');
-  set entrypointId(String v) {
+  @$pb.TagNumber(1)
+  $core.String get entrypointId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set entrypointId($core.String v) {
     $_setString(0, v);
   }
 
-  bool hasEntrypointId() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasEntrypointId() => $_has(0);
+  @$pb.TagNumber(1)
   void clearEntrypointId() => clearField(1);
 
-  int get size => $_get(1, 0);
-  set size(int v) {
+  @$pb.TagNumber(2)
+  $core.int get size => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set size($core.int v) {
     $_setSignedInt32(1, v);
   }
 
-  bool hasSize() => $_has(1);
+  @$pb.TagNumber(2)
+  $core.bool hasSize() => $_has(1);
+  @$pb.TagNumber(2)
   void clearSize() => clearField(2);
 
-  String get dart2jsVersion => $_getS(2, '');
-  set dart2jsVersion(String v) {
+  @$pb.TagNumber(3)
+  $core.String get dart2jsVersion => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set dart2jsVersion($core.String v) {
     $_setString(2, v);
   }
 
-  bool hasDart2jsVersion() => $_has(2);
+  @$pb.TagNumber(3)
+  $core.bool hasDart2jsVersion() => $_has(2);
+  @$pb.TagNumber(3)
   void clearDart2jsVersion() => clearField(3);
 
-  Int64 get compilationMoment => $_getI64(3);
-  set compilationMoment(Int64 v) {
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get compilationMoment => $_getI64(3);
+  @$pb.TagNumber(4)
+  set compilationMoment($fixnum.Int64 v) {
     $_setInt64(3, v);
   }
 
-  bool hasCompilationMoment() => $_has(3);
+  @$pb.TagNumber(4)
+  $core.bool hasCompilationMoment() => $_has(3);
+  @$pb.TagNumber(4)
   void clearCompilationMoment() => clearField(4);
 
-  Int64 get compilationDuration => $_getI64(4);
-  set compilationDuration(Int64 v) {
+  @$pb.TagNumber(5)
+  $fixnum.Int64 get compilationDuration => $_getI64(4);
+  @$pb.TagNumber(5)
+  set compilationDuration($fixnum.Int64 v) {
     $_setInt64(4, v);
   }
 
-  bool hasCompilationDuration() => $_has(4);
+  @$pb.TagNumber(5)
+  $core.bool hasCompilationDuration() => $_has(4);
+  @$pb.TagNumber(5)
   void clearCompilationDuration() => clearField(5);
 
-  Int64 get toProtoDuration => $_getI64(5);
-  set toProtoDuration(Int64 v) {
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get toProtoDuration => $_getI64(5);
+  @$pb.TagNumber(6)
+  set toProtoDuration($fixnum.Int64 v) {
     $_setInt64(5, v);
   }
 
-  bool hasToProtoDuration() => $_has(5);
+  @$pb.TagNumber(6)
+  $core.bool hasToProtoDuration() => $_has(5);
+  @$pb.TagNumber(6)
   void clearToProtoDuration() => clearField(6);
 
-  Int64 get dumpInfoDuration => $_getI64(6);
-  set dumpInfoDuration(Int64 v) {
+  @$pb.TagNumber(7)
+  $fixnum.Int64 get dumpInfoDuration => $_getI64(6);
+  @$pb.TagNumber(7)
+  set dumpInfoDuration($fixnum.Int64 v) {
     $_setInt64(6, v);
   }
 
-  bool hasDumpInfoDuration() => $_has(6);
+  @$pb.TagNumber(7)
+  $core.bool hasDumpInfoDuration() => $_has(6);
+  @$pb.TagNumber(7)
   void clearDumpInfoDuration() => clearField(7);
 
-  bool get noSuchMethodEnabled => $_get(7, false);
-  set noSuchMethodEnabled(bool v) {
+  @$pb.TagNumber(8)
+  $core.bool get noSuchMethodEnabled => $_getBF(7);
+  @$pb.TagNumber(8)
+  set noSuchMethodEnabled($core.bool v) {
     $_setBool(7, v);
   }
 
-  bool hasNoSuchMethodEnabled() => $_has(7);
+  @$pb.TagNumber(8)
+  $core.bool hasNoSuchMethodEnabled() => $_has(7);
+  @$pb.TagNumber(8)
   void clearNoSuchMethodEnabled() => clearField(8);
 
-  bool get isRuntimeTypeUsed => $_get(8, false);
-  set isRuntimeTypeUsed(bool v) {
+  @$pb.TagNumber(9)
+  $core.bool get isRuntimeTypeUsed => $_getBF(8);
+  @$pb.TagNumber(9)
+  set isRuntimeTypeUsed($core.bool v) {
     $_setBool(8, v);
   }
 
-  bool hasIsRuntimeTypeUsed() => $_has(8);
+  @$pb.TagNumber(9)
+  $core.bool hasIsRuntimeTypeUsed() => $_has(8);
+  @$pb.TagNumber(9)
   void clearIsRuntimeTypeUsed() => clearField(9);
 
-  bool get isIsolateUsed => $_get(9, false);
-  set isIsolateUsed(bool v) {
+  @$pb.TagNumber(10)
+  $core.bool get isIsolateUsed => $_getBF(9);
+  @$pb.TagNumber(10)
+  set isIsolateUsed($core.bool v) {
     $_setBool(9, v);
   }
 
-  bool hasIsIsolateUsed() => $_has(9);
+  @$pb.TagNumber(10)
+  $core.bool hasIsIsolateUsed() => $_has(9);
+  @$pb.TagNumber(10)
   void clearIsIsolateUsed() => clearField(10);
 
-  bool get isFunctionApplyUsed => $_get(10, false);
-  set isFunctionApplyUsed(bool v) {
+  @$pb.TagNumber(11)
+  $core.bool get isFunctionApplyUsed => $_getBF(10);
+  @$pb.TagNumber(11)
+  set isFunctionApplyUsed($core.bool v) {
     $_setBool(10, v);
   }
 
-  bool hasIsFunctionApplyUsed() => $_has(10);
+  @$pb.TagNumber(11)
+  $core.bool hasIsFunctionApplyUsed() => $_has(10);
+  @$pb.TagNumber(11)
   void clearIsFunctionApplyUsed() => clearField(11);
 
-  bool get isMirrorsUsed => $_get(11, false);
-  set isMirrorsUsed(bool v) {
+  @$pb.TagNumber(12)
+  $core.bool get isMirrorsUsed => $_getBF(11);
+  @$pb.TagNumber(12)
+  set isMirrorsUsed($core.bool v) {
     $_setBool(11, v);
   }
 
-  bool hasIsMirrorsUsed() => $_has(11);
+  @$pb.TagNumber(12)
+  $core.bool hasIsMirrorsUsed() => $_has(11);
+  @$pb.TagNumber(12)
   void clearIsMirrorsUsed() => clearField(12);
 
-  bool get minified => $_get(12, false);
-  set minified(bool v) {
+  @$pb.TagNumber(13)
+  $core.bool get minified => $_getBF(12);
+  @$pb.TagNumber(13)
+  set minified($core.bool v) {
     $_setBool(12, v);
   }
 
-  bool hasMinified() => $_has(12);
+  @$pb.TagNumber(13)
+  $core.bool hasMinified() => $_has(12);
+  @$pb.TagNumber(13)
   void clearMinified() => clearField(13);
 }
 
 class LibraryInfoPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('LibraryInfoPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('LibraryInfoPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
     ..aOS(1, 'uri')
     ..pPS(2, 'childrenIds')
     ..hasRequiredFields = false;
 
-  LibraryInfoPB() : super();
-  LibraryInfoPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  LibraryInfoPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  LibraryInfoPB clone() => new LibraryInfoPB()..mergeFromMessage(this);
+  LibraryInfoPB._() : super();
+  factory LibraryInfoPB() => create();
+  factory LibraryInfoPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LibraryInfoPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  LibraryInfoPB clone() => LibraryInfoPB()..mergeFromMessage(this);
   LibraryInfoPB copyWith(void Function(LibraryInfoPB) updates) =>
       super.copyWith((message) => updates(message as LibraryInfoPB));
   $pb.BuilderInfo get info_ => _i;
-  static LibraryInfoPB create() => new LibraryInfoPB();
+  @$core.pragma('dart2js:noInline')
+  static LibraryInfoPB create() => LibraryInfoPB._();
+  LibraryInfoPB createEmptyInstance() => create();
   static $pb.PbList<LibraryInfoPB> createRepeated() =>
-      new $pb.PbList<LibraryInfoPB>();
-  static LibraryInfoPB getDefault() => _defaultInstance ??= create()..freeze();
+      $pb.PbList<LibraryInfoPB>();
+  @$core.pragma('dart2js:noInline')
+  static LibraryInfoPB getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<LibraryInfoPB>(create);
   static LibraryInfoPB _defaultInstance;
-  static void $checkItem(LibraryInfoPB v) {
-    if (v is! LibraryInfoPB) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
-  String get uri => $_getS(0, '');
-  set uri(String v) {
+  @$pb.TagNumber(1)
+  $core.String get uri => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set uri($core.String v) {
     $_setString(0, v);
   }
 
-  bool hasUri() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasUri() => $_has(0);
+  @$pb.TagNumber(1)
   void clearUri() => clearField(1);
 
-  List<String> get childrenIds => $_getList(1);
+  @$pb.TagNumber(2)
+  $core.List<$core.String> get childrenIds => $_getList(1);
 }
 
 class OutputUnitInfoPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('OutputUnitInfoPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('OutputUnitInfoPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
     ..pPS(1, 'imports')
     ..hasRequiredFields = false;
 
-  OutputUnitInfoPB() : super();
-  OutputUnitInfoPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  OutputUnitInfoPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  OutputUnitInfoPB clone() => new OutputUnitInfoPB()..mergeFromMessage(this);
+  OutputUnitInfoPB._() : super();
+  factory OutputUnitInfoPB() => create();
+  factory OutputUnitInfoPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory OutputUnitInfoPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  OutputUnitInfoPB clone() => OutputUnitInfoPB()..mergeFromMessage(this);
   OutputUnitInfoPB copyWith(void Function(OutputUnitInfoPB) updates) =>
       super.copyWith((message) => updates(message as OutputUnitInfoPB));
   $pb.BuilderInfo get info_ => _i;
-  static OutputUnitInfoPB create() => new OutputUnitInfoPB();
+  @$core.pragma('dart2js:noInline')
+  static OutputUnitInfoPB create() => OutputUnitInfoPB._();
+  OutputUnitInfoPB createEmptyInstance() => create();
   static $pb.PbList<OutputUnitInfoPB> createRepeated() =>
-      new $pb.PbList<OutputUnitInfoPB>();
-  static OutputUnitInfoPB getDefault() =>
-      _defaultInstance ??= create()..freeze();
+      $pb.PbList<OutputUnitInfoPB>();
+  @$core.pragma('dart2js:noInline')
+  static OutputUnitInfoPB getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<OutputUnitInfoPB>(create);
   static OutputUnitInfoPB _defaultInstance;
-  static void $checkItem(OutputUnitInfoPB v) {
-    if (v is! OutputUnitInfoPB) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
-  List<String> get imports => $_getList(0);
+  @$pb.TagNumber(1)
+  $core.List<$core.String> get imports => $_getList(0);
 }
 
 class ClassInfoPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('ClassInfoPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ClassInfoPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
     ..aOB(1, 'isAbstract')
     ..pPS(2, 'childrenIds')
     ..hasRequiredFields = false;
 
-  ClassInfoPB() : super();
-  ClassInfoPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  ClassInfoPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  ClassInfoPB clone() => new ClassInfoPB()..mergeFromMessage(this);
+  ClassInfoPB._() : super();
+  factory ClassInfoPB() => create();
+  factory ClassInfoPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ClassInfoPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  ClassInfoPB clone() => ClassInfoPB()..mergeFromMessage(this);
   ClassInfoPB copyWith(void Function(ClassInfoPB) updates) =>
       super.copyWith((message) => updates(message as ClassInfoPB));
   $pb.BuilderInfo get info_ => _i;
-  static ClassInfoPB create() => new ClassInfoPB();
-  static $pb.PbList<ClassInfoPB> createRepeated() =>
-      new $pb.PbList<ClassInfoPB>();
-  static ClassInfoPB getDefault() => _defaultInstance ??= create()..freeze();
+  @$core.pragma('dart2js:noInline')
+  static ClassInfoPB create() => ClassInfoPB._();
+  ClassInfoPB createEmptyInstance() => create();
+  static $pb.PbList<ClassInfoPB> createRepeated() => $pb.PbList<ClassInfoPB>();
+  @$core.pragma('dart2js:noInline')
+  static ClassInfoPB getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ClassInfoPB>(create);
   static ClassInfoPB _defaultInstance;
-  static void $checkItem(ClassInfoPB v) {
-    if (v is! ClassInfoPB) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
-  bool get isAbstract => $_get(0, false);
-  set isAbstract(bool v) {
+  @$pb.TagNumber(1)
+  $core.bool get isAbstract => $_getBF(0);
+  @$pb.TagNumber(1)
+  set isAbstract($core.bool v) {
     $_setBool(0, v);
   }
 
-  bool hasIsAbstract() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasIsAbstract() => $_has(0);
+  @$pb.TagNumber(1)
   void clearIsAbstract() => clearField(1);
 
-  List<String> get childrenIds => $_getList(1);
+  @$pb.TagNumber(2)
+  $core.List<$core.String> get childrenIds => $_getList(1);
 }
 
 class ConstantInfoPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('ConstantInfoPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ConstantInfoPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
     ..aOS(1, 'code')
     ..hasRequiredFields = false;
 
-  ConstantInfoPB() : super();
-  ConstantInfoPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  ConstantInfoPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  ConstantInfoPB clone() => new ConstantInfoPB()..mergeFromMessage(this);
+  ConstantInfoPB._() : super();
+  factory ConstantInfoPB() => create();
+  factory ConstantInfoPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ConstantInfoPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  ConstantInfoPB clone() => ConstantInfoPB()..mergeFromMessage(this);
   ConstantInfoPB copyWith(void Function(ConstantInfoPB) updates) =>
       super.copyWith((message) => updates(message as ConstantInfoPB));
   $pb.BuilderInfo get info_ => _i;
-  static ConstantInfoPB create() => new ConstantInfoPB();
+  @$core.pragma('dart2js:noInline')
+  static ConstantInfoPB create() => ConstantInfoPB._();
+  ConstantInfoPB createEmptyInstance() => create();
   static $pb.PbList<ConstantInfoPB> createRepeated() =>
-      new $pb.PbList<ConstantInfoPB>();
-  static ConstantInfoPB getDefault() => _defaultInstance ??= create()..freeze();
+      $pb.PbList<ConstantInfoPB>();
+  @$core.pragma('dart2js:noInline')
+  static ConstantInfoPB getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ConstantInfoPB>(create);
   static ConstantInfoPB _defaultInstance;
-  static void $checkItem(ConstantInfoPB v) {
-    if (v is! ConstantInfoPB) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
-  String get code => $_getS(0, '');
-  set code(String v) {
+  @$pb.TagNumber(1)
+  $core.String get code => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set code($core.String v) {
     $_setString(0, v);
   }
 
-  bool hasCode() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasCode() => $_has(0);
+  @$pb.TagNumber(1)
   void clearCode() => clearField(1);
 }
 
 class FieldInfoPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('FieldInfoPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FieldInfoPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
     ..aOS(1, 'type')
     ..aOS(2, 'inferredType')
     ..pPS(3, 'childrenIds')
@@ -615,434 +772,547 @@ class FieldInfoPB extends $pb.GeneratedMessage {
     ..aOS(6, 'initializerId')
     ..hasRequiredFields = false;
 
-  FieldInfoPB() : super();
-  FieldInfoPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  FieldInfoPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  FieldInfoPB clone() => new FieldInfoPB()..mergeFromMessage(this);
+  FieldInfoPB._() : super();
+  factory FieldInfoPB() => create();
+  factory FieldInfoPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory FieldInfoPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  FieldInfoPB clone() => FieldInfoPB()..mergeFromMessage(this);
   FieldInfoPB copyWith(void Function(FieldInfoPB) updates) =>
       super.copyWith((message) => updates(message as FieldInfoPB));
   $pb.BuilderInfo get info_ => _i;
-  static FieldInfoPB create() => new FieldInfoPB();
-  static $pb.PbList<FieldInfoPB> createRepeated() =>
-      new $pb.PbList<FieldInfoPB>();
-  static FieldInfoPB getDefault() => _defaultInstance ??= create()..freeze();
+  @$core.pragma('dart2js:noInline')
+  static FieldInfoPB create() => FieldInfoPB._();
+  FieldInfoPB createEmptyInstance() => create();
+  static $pb.PbList<FieldInfoPB> createRepeated() => $pb.PbList<FieldInfoPB>();
+  @$core.pragma('dart2js:noInline')
+  static FieldInfoPB getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<FieldInfoPB>(create);
   static FieldInfoPB _defaultInstance;
-  static void $checkItem(FieldInfoPB v) {
-    if (v is! FieldInfoPB) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
-  String get type => $_getS(0, '');
-  set type(String v) {
+  @$pb.TagNumber(1)
+  $core.String get type => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set type($core.String v) {
     $_setString(0, v);
   }
 
-  bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
   void clearType() => clearField(1);
 
-  String get inferredType => $_getS(1, '');
-  set inferredType(String v) {
+  @$pb.TagNumber(2)
+  $core.String get inferredType => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set inferredType($core.String v) {
     $_setString(1, v);
   }
 
-  bool hasInferredType() => $_has(1);
+  @$pb.TagNumber(2)
+  $core.bool hasInferredType() => $_has(1);
+  @$pb.TagNumber(2)
   void clearInferredType() => clearField(2);
 
-  List<String> get childrenIds => $_getList(2);
+  @$pb.TagNumber(3)
+  $core.List<$core.String> get childrenIds => $_getList(2);
 
-  String get code => $_getS(3, '');
-  set code(String v) {
+  @$pb.TagNumber(4)
+  $core.String get code => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set code($core.String v) {
     $_setString(3, v);
   }
 
-  bool hasCode() => $_has(3);
+  @$pb.TagNumber(4)
+  $core.bool hasCode() => $_has(3);
+  @$pb.TagNumber(4)
   void clearCode() => clearField(4);
 
-  bool get isConst => $_get(4, false);
-  set isConst(bool v) {
+  @$pb.TagNumber(5)
+  $core.bool get isConst => $_getBF(4);
+  @$pb.TagNumber(5)
+  set isConst($core.bool v) {
     $_setBool(4, v);
   }
 
-  bool hasIsConst() => $_has(4);
+  @$pb.TagNumber(5)
+  $core.bool hasIsConst() => $_has(4);
+  @$pb.TagNumber(5)
   void clearIsConst() => clearField(5);
 
-  String get initializerId => $_getS(5, '');
-  set initializerId(String v) {
+  @$pb.TagNumber(6)
+  $core.String get initializerId => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set initializerId($core.String v) {
     $_setString(5, v);
   }
 
-  bool hasInitializerId() => $_has(5);
+  @$pb.TagNumber(6)
+  $core.bool hasInitializerId() => $_has(5);
+  @$pb.TagNumber(6)
   void clearInitializerId() => clearField(6);
 }
 
 class TypedefInfoPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('TypedefInfoPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('TypedefInfoPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
     ..aOS(1, 'type')
     ..hasRequiredFields = false;
 
-  TypedefInfoPB() : super();
-  TypedefInfoPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  TypedefInfoPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  TypedefInfoPB clone() => new TypedefInfoPB()..mergeFromMessage(this);
+  TypedefInfoPB._() : super();
+  factory TypedefInfoPB() => create();
+  factory TypedefInfoPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory TypedefInfoPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  TypedefInfoPB clone() => TypedefInfoPB()..mergeFromMessage(this);
   TypedefInfoPB copyWith(void Function(TypedefInfoPB) updates) =>
       super.copyWith((message) => updates(message as TypedefInfoPB));
   $pb.BuilderInfo get info_ => _i;
-  static TypedefInfoPB create() => new TypedefInfoPB();
+  @$core.pragma('dart2js:noInline')
+  static TypedefInfoPB create() => TypedefInfoPB._();
+  TypedefInfoPB createEmptyInstance() => create();
   static $pb.PbList<TypedefInfoPB> createRepeated() =>
-      new $pb.PbList<TypedefInfoPB>();
-  static TypedefInfoPB getDefault() => _defaultInstance ??= create()..freeze();
+      $pb.PbList<TypedefInfoPB>();
+  @$core.pragma('dart2js:noInline')
+  static TypedefInfoPB getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<TypedefInfoPB>(create);
   static TypedefInfoPB _defaultInstance;
-  static void $checkItem(TypedefInfoPB v) {
-    if (v is! TypedefInfoPB) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
-  String get type => $_getS(0, '');
-  set type(String v) {
+  @$pb.TagNumber(1)
+  $core.String get type => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set type($core.String v) {
     $_setString(0, v);
   }
 
-  bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
   void clearType() => clearField(1);
 }
 
 class FunctionModifiersPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('FunctionModifiersPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FunctionModifiersPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
     ..aOB(1, 'isStatic')
     ..aOB(2, 'isConst')
     ..aOB(3, 'isFactory')
     ..aOB(4, 'isExternal')
     ..hasRequiredFields = false;
 
-  FunctionModifiersPB() : super();
-  FunctionModifiersPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  FunctionModifiersPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  FunctionModifiersPB clone() =>
-      new FunctionModifiersPB()..mergeFromMessage(this);
+  FunctionModifiersPB._() : super();
+  factory FunctionModifiersPB() => create();
+  factory FunctionModifiersPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory FunctionModifiersPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  FunctionModifiersPB clone() => FunctionModifiersPB()..mergeFromMessage(this);
   FunctionModifiersPB copyWith(void Function(FunctionModifiersPB) updates) =>
       super.copyWith((message) => updates(message as FunctionModifiersPB));
   $pb.BuilderInfo get info_ => _i;
-  static FunctionModifiersPB create() => new FunctionModifiersPB();
+  @$core.pragma('dart2js:noInline')
+  static FunctionModifiersPB create() => FunctionModifiersPB._();
+  FunctionModifiersPB createEmptyInstance() => create();
   static $pb.PbList<FunctionModifiersPB> createRepeated() =>
-      new $pb.PbList<FunctionModifiersPB>();
-  static FunctionModifiersPB getDefault() =>
-      _defaultInstance ??= create()..freeze();
+      $pb.PbList<FunctionModifiersPB>();
+  @$core.pragma('dart2js:noInline')
+  static FunctionModifiersPB getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<FunctionModifiersPB>(create);
   static FunctionModifiersPB _defaultInstance;
-  static void $checkItem(FunctionModifiersPB v) {
-    if (v is! FunctionModifiersPB)
-      $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
-  bool get isStatic => $_get(0, false);
-  set isStatic(bool v) {
+  @$pb.TagNumber(1)
+  $core.bool get isStatic => $_getBF(0);
+  @$pb.TagNumber(1)
+  set isStatic($core.bool v) {
     $_setBool(0, v);
   }
 
-  bool hasIsStatic() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasIsStatic() => $_has(0);
+  @$pb.TagNumber(1)
   void clearIsStatic() => clearField(1);
 
-  bool get isConst => $_get(1, false);
-  set isConst(bool v) {
+  @$pb.TagNumber(2)
+  $core.bool get isConst => $_getBF(1);
+  @$pb.TagNumber(2)
+  set isConst($core.bool v) {
     $_setBool(1, v);
   }
 
-  bool hasIsConst() => $_has(1);
+  @$pb.TagNumber(2)
+  $core.bool hasIsConst() => $_has(1);
+  @$pb.TagNumber(2)
   void clearIsConst() => clearField(2);
 
-  bool get isFactory => $_get(2, false);
-  set isFactory(bool v) {
+  @$pb.TagNumber(3)
+  $core.bool get isFactory => $_getBF(2);
+  @$pb.TagNumber(3)
+  set isFactory($core.bool v) {
     $_setBool(2, v);
   }
 
-  bool hasIsFactory() => $_has(2);
+  @$pb.TagNumber(3)
+  $core.bool hasIsFactory() => $_has(2);
+  @$pb.TagNumber(3)
   void clearIsFactory() => clearField(3);
 
-  bool get isExternal => $_get(3, false);
-  set isExternal(bool v) {
+  @$pb.TagNumber(4)
+  $core.bool get isExternal => $_getBF(3);
+  @$pb.TagNumber(4)
+  set isExternal($core.bool v) {
     $_setBool(3, v);
   }
 
-  bool hasIsExternal() => $_has(3);
+  @$pb.TagNumber(4)
+  $core.bool hasIsExternal() => $_has(3);
+  @$pb.TagNumber(4)
   void clearIsExternal() => clearField(4);
 }
 
 class ParameterInfoPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('ParameterInfoPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ParameterInfoPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
     ..aOS(1, 'name')
     ..aOS(2, 'type')
     ..aOS(3, 'declaredType')
     ..hasRequiredFields = false;
 
-  ParameterInfoPB() : super();
-  ParameterInfoPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  ParameterInfoPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  ParameterInfoPB clone() => new ParameterInfoPB()..mergeFromMessage(this);
+  ParameterInfoPB._() : super();
+  factory ParameterInfoPB() => create();
+  factory ParameterInfoPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ParameterInfoPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  ParameterInfoPB clone() => ParameterInfoPB()..mergeFromMessage(this);
   ParameterInfoPB copyWith(void Function(ParameterInfoPB) updates) =>
       super.copyWith((message) => updates(message as ParameterInfoPB));
   $pb.BuilderInfo get info_ => _i;
-  static ParameterInfoPB create() => new ParameterInfoPB();
+  @$core.pragma('dart2js:noInline')
+  static ParameterInfoPB create() => ParameterInfoPB._();
+  ParameterInfoPB createEmptyInstance() => create();
   static $pb.PbList<ParameterInfoPB> createRepeated() =>
-      new $pb.PbList<ParameterInfoPB>();
-  static ParameterInfoPB getDefault() =>
-      _defaultInstance ??= create()..freeze();
+      $pb.PbList<ParameterInfoPB>();
+  @$core.pragma('dart2js:noInline')
+  static ParameterInfoPB getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ParameterInfoPB>(create);
   static ParameterInfoPB _defaultInstance;
-  static void $checkItem(ParameterInfoPB v) {
-    if (v is! ParameterInfoPB) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
-  String get name => $_getS(0, '');
-  set name(String v) {
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) {
     $_setString(0, v);
   }
 
-  bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
   void clearName() => clearField(1);
 
-  String get type => $_getS(1, '');
-  set type(String v) {
+  @$pb.TagNumber(2)
+  $core.String get type => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set type($core.String v) {
     $_setString(1, v);
   }
 
-  bool hasType() => $_has(1);
+  @$pb.TagNumber(2)
+  $core.bool hasType() => $_has(1);
+  @$pb.TagNumber(2)
   void clearType() => clearField(2);
 
-  String get declaredType => $_getS(2, '');
-  set declaredType(String v) {
+  @$pb.TagNumber(3)
+  $core.String get declaredType => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set declaredType($core.String v) {
     $_setString(2, v);
   }
 
-  bool hasDeclaredType() => $_has(2);
+  @$pb.TagNumber(3)
+  $core.bool hasDeclaredType() => $_has(2);
+  @$pb.TagNumber(3)
   void clearDeclaredType() => clearField(3);
 }
 
 class FunctionInfoPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('FunctionInfoPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
-    ..a<FunctionModifiersPB>(1, 'functionModifiers', $pb.PbFieldType.OM,
-        FunctionModifiersPB.getDefault, FunctionModifiersPB.create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FunctionInfoPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
+    ..aOM<FunctionModifiersPB>(1, 'functionModifiers',
+        subBuilder: FunctionModifiersPB.create)
     ..pPS(2, 'childrenIds')
     ..aOS(3, 'returnType')
     ..aOS(4, 'inferredReturnType')
-    ..pp<ParameterInfoPB>(5, 'parameters', $pb.PbFieldType.PM,
-        ParameterInfoPB.$checkItem, ParameterInfoPB.create)
+    ..pc<ParameterInfoPB>(5, 'parameters', $pb.PbFieldType.PM,
+        subBuilder: ParameterInfoPB.create)
     ..aOS(6, 'sideEffects')
-    ..a<int>(7, 'inlinedCount', $pb.PbFieldType.O3)
+    ..a<$core.int>(7, 'inlinedCount', $pb.PbFieldType.O3)
     ..aOS(8, 'code')
     ..hasRequiredFields = false;
 
-  FunctionInfoPB() : super();
-  FunctionInfoPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  FunctionInfoPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  FunctionInfoPB clone() => new FunctionInfoPB()..mergeFromMessage(this);
+  FunctionInfoPB._() : super();
+  factory FunctionInfoPB() => create();
+  factory FunctionInfoPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory FunctionInfoPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  FunctionInfoPB clone() => FunctionInfoPB()..mergeFromMessage(this);
   FunctionInfoPB copyWith(void Function(FunctionInfoPB) updates) =>
       super.copyWith((message) => updates(message as FunctionInfoPB));
   $pb.BuilderInfo get info_ => _i;
-  static FunctionInfoPB create() => new FunctionInfoPB();
+  @$core.pragma('dart2js:noInline')
+  static FunctionInfoPB create() => FunctionInfoPB._();
+  FunctionInfoPB createEmptyInstance() => create();
   static $pb.PbList<FunctionInfoPB> createRepeated() =>
-      new $pb.PbList<FunctionInfoPB>();
-  static FunctionInfoPB getDefault() => _defaultInstance ??= create()..freeze();
+      $pb.PbList<FunctionInfoPB>();
+  @$core.pragma('dart2js:noInline')
+  static FunctionInfoPB getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<FunctionInfoPB>(create);
   static FunctionInfoPB _defaultInstance;
-  static void $checkItem(FunctionInfoPB v) {
-    if (v is! FunctionInfoPB) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
+  @$pb.TagNumber(1)
   FunctionModifiersPB get functionModifiers => $_getN(0);
+  @$pb.TagNumber(1)
   set functionModifiers(FunctionModifiersPB v) {
     setField(1, v);
   }
 
-  bool hasFunctionModifiers() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasFunctionModifiers() => $_has(0);
+  @$pb.TagNumber(1)
   void clearFunctionModifiers() => clearField(1);
+  @$pb.TagNumber(1)
+  FunctionModifiersPB ensureFunctionModifiers() => $_ensure(0);
 
-  List<String> get childrenIds => $_getList(1);
+  @$pb.TagNumber(2)
+  $core.List<$core.String> get childrenIds => $_getList(1);
 
-  String get returnType => $_getS(2, '');
-  set returnType(String v) {
+  @$pb.TagNumber(3)
+  $core.String get returnType => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set returnType($core.String v) {
     $_setString(2, v);
   }
 
-  bool hasReturnType() => $_has(2);
+  @$pb.TagNumber(3)
+  $core.bool hasReturnType() => $_has(2);
+  @$pb.TagNumber(3)
   void clearReturnType() => clearField(3);
 
-  String get inferredReturnType => $_getS(3, '');
-  set inferredReturnType(String v) {
+  @$pb.TagNumber(4)
+  $core.String get inferredReturnType => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set inferredReturnType($core.String v) {
     $_setString(3, v);
   }
 
-  bool hasInferredReturnType() => $_has(3);
+  @$pb.TagNumber(4)
+  $core.bool hasInferredReturnType() => $_has(3);
+  @$pb.TagNumber(4)
   void clearInferredReturnType() => clearField(4);
 
-  List<ParameterInfoPB> get parameters => $_getList(4);
+  @$pb.TagNumber(5)
+  $core.List<ParameterInfoPB> get parameters => $_getList(4);
 
-  String get sideEffects => $_getS(5, '');
-  set sideEffects(String v) {
+  @$pb.TagNumber(6)
+  $core.String get sideEffects => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set sideEffects($core.String v) {
     $_setString(5, v);
   }
 
-  bool hasSideEffects() => $_has(5);
+  @$pb.TagNumber(6)
+  $core.bool hasSideEffects() => $_has(5);
+  @$pb.TagNumber(6)
   void clearSideEffects() => clearField(6);
 
-  int get inlinedCount => $_get(6, 0);
-  set inlinedCount(int v) {
+  @$pb.TagNumber(7)
+  $core.int get inlinedCount => $_getIZ(6);
+  @$pb.TagNumber(7)
+  set inlinedCount($core.int v) {
     $_setSignedInt32(6, v);
   }
 
-  bool hasInlinedCount() => $_has(6);
+  @$pb.TagNumber(7)
+  $core.bool hasInlinedCount() => $_has(6);
+  @$pb.TagNumber(7)
   void clearInlinedCount() => clearField(7);
 
-  String get code => $_getS(7, '');
-  set code(String v) {
+  @$pb.TagNumber(8)
+  $core.String get code => $_getSZ(7);
+  @$pb.TagNumber(8)
+  set code($core.String v) {
     $_setString(7, v);
   }
 
-  bool hasCode() => $_has(7);
+  @$pb.TagNumber(8)
+  $core.bool hasCode() => $_has(7);
+  @$pb.TagNumber(8)
   void clearCode() => clearField(8);
 }
 
 class ClosureInfoPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('ClosureInfoPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ClosureInfoPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
     ..aOS(1, 'functionId')
     ..hasRequiredFields = false;
 
-  ClosureInfoPB() : super();
-  ClosureInfoPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  ClosureInfoPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  ClosureInfoPB clone() => new ClosureInfoPB()..mergeFromMessage(this);
+  ClosureInfoPB._() : super();
+  factory ClosureInfoPB() => create();
+  factory ClosureInfoPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ClosureInfoPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  ClosureInfoPB clone() => ClosureInfoPB()..mergeFromMessage(this);
   ClosureInfoPB copyWith(void Function(ClosureInfoPB) updates) =>
       super.copyWith((message) => updates(message as ClosureInfoPB));
   $pb.BuilderInfo get info_ => _i;
-  static ClosureInfoPB create() => new ClosureInfoPB();
+  @$core.pragma('dart2js:noInline')
+  static ClosureInfoPB create() => ClosureInfoPB._();
+  ClosureInfoPB createEmptyInstance() => create();
   static $pb.PbList<ClosureInfoPB> createRepeated() =>
-      new $pb.PbList<ClosureInfoPB>();
-  static ClosureInfoPB getDefault() => _defaultInstance ??= create()..freeze();
+      $pb.PbList<ClosureInfoPB>();
+  @$core.pragma('dart2js:noInline')
+  static ClosureInfoPB getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ClosureInfoPB>(create);
   static ClosureInfoPB _defaultInstance;
-  static void $checkItem(ClosureInfoPB v) {
-    if (v is! ClosureInfoPB) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
-  String get functionId => $_getS(0, '');
-  set functionId(String v) {
+  @$pb.TagNumber(1)
+  $core.String get functionId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set functionId($core.String v) {
     $_setString(0, v);
   }
 
-  bool hasFunctionId() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasFunctionId() => $_has(0);
+  @$pb.TagNumber(1)
   void clearFunctionId() => clearField(1);
 }
 
 class DeferredImportPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('DeferredImportPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('DeferredImportPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
     ..aOS(1, 'prefix')
     ..pPS(2, 'files')
     ..hasRequiredFields = false;
 
-  DeferredImportPB() : super();
-  DeferredImportPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  DeferredImportPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
-  DeferredImportPB clone() => new DeferredImportPB()..mergeFromMessage(this);
+  DeferredImportPB._() : super();
+  factory DeferredImportPB() => create();
+  factory DeferredImportPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory DeferredImportPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  DeferredImportPB clone() => DeferredImportPB()..mergeFromMessage(this);
   DeferredImportPB copyWith(void Function(DeferredImportPB) updates) =>
       super.copyWith((message) => updates(message as DeferredImportPB));
   $pb.BuilderInfo get info_ => _i;
-  static DeferredImportPB create() => new DeferredImportPB();
+  @$core.pragma('dart2js:noInline')
+  static DeferredImportPB create() => DeferredImportPB._();
+  DeferredImportPB createEmptyInstance() => create();
   static $pb.PbList<DeferredImportPB> createRepeated() =>
-      new $pb.PbList<DeferredImportPB>();
-  static DeferredImportPB getDefault() =>
-      _defaultInstance ??= create()..freeze();
+      $pb.PbList<DeferredImportPB>();
+  @$core.pragma('dart2js:noInline')
+  static DeferredImportPB getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<DeferredImportPB>(create);
   static DeferredImportPB _defaultInstance;
-  static void $checkItem(DeferredImportPB v) {
-    if (v is! DeferredImportPB) $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
-  String get prefix => $_getS(0, '');
-  set prefix(String v) {
+  @$pb.TagNumber(1)
+  $core.String get prefix => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set prefix($core.String v) {
     $_setString(0, v);
   }
 
-  bool hasPrefix() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasPrefix() => $_has(0);
+  @$pb.TagNumber(1)
   void clearPrefix() => clearField(1);
 
-  List<String> get files => $_getList(1);
+  @$pb.TagNumber(2)
+  $core.List<$core.String> get files => $_getList(1);
 }
 
 class LibraryDeferredImportsPB extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo(
-      'LibraryDeferredImportsPB',
-      package: const $pb.PackageName('dart2js_info.proto'))
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('LibraryDeferredImportsPB',
+      package: const $pb.PackageName('dart2js_info.proto'),
+      createEmptyInstance: create)
     ..aOS(1, 'libraryUri')
     ..aOS(2, 'libraryName')
-    ..pp<DeferredImportPB>(3, 'imports', $pb.PbFieldType.PM,
-        DeferredImportPB.$checkItem, DeferredImportPB.create)
+    ..pc<DeferredImportPB>(3, 'imports', $pb.PbFieldType.PM,
+        subBuilder: DeferredImportPB.create)
     ..hasRequiredFields = false;
 
-  LibraryDeferredImportsPB() : super();
-  LibraryDeferredImportsPB.fromBuffer(List<int> i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromBuffer(i, r);
-  LibraryDeferredImportsPB.fromJson(String i,
-      [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
-      : super.fromJson(i, r);
+  LibraryDeferredImportsPB._() : super();
+  factory LibraryDeferredImportsPB() => create();
+  factory LibraryDeferredImportsPB.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LibraryDeferredImportsPB.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
   LibraryDeferredImportsPB clone() =>
-      new LibraryDeferredImportsPB()..mergeFromMessage(this);
+      LibraryDeferredImportsPB()..mergeFromMessage(this);
   LibraryDeferredImportsPB copyWith(
           void Function(LibraryDeferredImportsPB) updates) =>
       super.copyWith((message) => updates(message as LibraryDeferredImportsPB));
   $pb.BuilderInfo get info_ => _i;
-  static LibraryDeferredImportsPB create() => new LibraryDeferredImportsPB();
+  @$core.pragma('dart2js:noInline')
+  static LibraryDeferredImportsPB create() => LibraryDeferredImportsPB._();
+  LibraryDeferredImportsPB createEmptyInstance() => create();
   static $pb.PbList<LibraryDeferredImportsPB> createRepeated() =>
-      new $pb.PbList<LibraryDeferredImportsPB>();
-  static LibraryDeferredImportsPB getDefault() =>
-      _defaultInstance ??= create()..freeze();
+      $pb.PbList<LibraryDeferredImportsPB>();
+  @$core.pragma('dart2js:noInline')
+  static LibraryDeferredImportsPB getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<LibraryDeferredImportsPB>(create);
   static LibraryDeferredImportsPB _defaultInstance;
-  static void $checkItem(LibraryDeferredImportsPB v) {
-    if (v is! LibraryDeferredImportsPB)
-      $pb.checkItemFailed(v, _i.qualifiedMessageName);
-  }
 
-  String get libraryUri => $_getS(0, '');
-  set libraryUri(String v) {
+  @$pb.TagNumber(1)
+  $core.String get libraryUri => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set libraryUri($core.String v) {
     $_setString(0, v);
   }
 
-  bool hasLibraryUri() => $_has(0);
+  @$pb.TagNumber(1)
+  $core.bool hasLibraryUri() => $_has(0);
+  @$pb.TagNumber(1)
   void clearLibraryUri() => clearField(1);
 
-  String get libraryName => $_getS(1, '');
-  set libraryName(String v) {
+  @$pb.TagNumber(2)
+  $core.String get libraryName => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set libraryName($core.String v) {
     $_setString(1, v);
   }
 
-  bool hasLibraryName() => $_has(1);
+  @$pb.TagNumber(2)
+  $core.bool hasLibraryName() => $_has(1);
+  @$pb.TagNumber(2)
   void clearLibraryName() => clearField(2);
 
-  List<DeferredImportPB> get imports => $_getList(2);
+  @$pb.TagNumber(3)
+  $core.List<DeferredImportPB> get imports => $_getList(2);
 }

--- a/lib/src/proto/info.pbenum.dart
+++ b/lib/src/proto/info.pbenum.dart
@@ -1,5 +1,6 @@
 ///
 //  Generated code. Do not modify.
 //  source: info.proto
-///
-// ignore_for_file: non_constant_identifier_names,library_prefixes,unused_import
+//
+// @dart = 2.3
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type

--- a/lib/src/proto/info.pbjson.dart
+++ b/lib/src/proto/info.pbjson.dart
@@ -1,8 +1,9 @@
 ///
 //  Generated code. Do not modify.
 //  source: info.proto
-///
-// ignore_for_file: non_constant_identifier_names,library_prefixes,unused_import
+//
+// @dart = 2.3
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
 
 const DependencyInfoPB$json = const {
   '1': 'DependencyInfoPB',

--- a/lib/src/proto/info.pbserver.dart
+++ b/lib/src/proto/info.pbserver.dart
@@ -1,7 +1,8 @@
 ///
 //  Generated code. Do not modify.
 //  source: info.proto
-///
-// ignore_for_file: non_constant_identifier_names,library_prefixes,unused_import
+//
+// @dart = 2.3
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
 
 export 'info.pb.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart2js_info
-version: 0.6.1
+version: 0.6.2
 
 description: >
   Libraries and tools to process data produced when running dart2js with
@@ -16,7 +16,7 @@ dependencies:
   collection: ^1.10.1
   fixnum: ^0.10.5
   path: ^1.3.6
-  protobuf: ^0.10.0
+  protobuf: ^1.0.1
   quiver: '>=0.29.0 <3.0.0'
   shelf: ^0.7.3
   shelf_static: ^0.2.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/dart2js_info/
 
 environment:
-  sdk: '>=2.0.0-dev.17.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   args: ^1.4.3

--- a/test/json_to_proto_deferred_test.dart
+++ b/test/json_to_proto_deferred_test.dart
@@ -28,11 +28,7 @@ main() {
       expect(import.files, hasLength(1));
       expect(import.files.first, 'hello_world_deferred.js_1.part.js');
 
-      // Dart protobuf doesn't support maps, translate the info list into
-      // a map for associative verifications.
-      final infoMap = <String, InfoPB>{};
-      infoMap.addEntries(proto.allInfos.map(
-          (entry) => new MapEntry<String, InfoPB>(entry.key, entry.value)));
+      final infoMap = proto.allInfos;
 
       final entrypoint = infoMap[proto.program.entrypointId];
       expect(entrypoint, isNotNull);

--- a/test/json_to_proto_test.dart
+++ b/test/json_to_proto_test.dart
@@ -41,7 +41,7 @@ main() {
         expectedPrefixes[kind] = kindToString(kind) + '/';
       }
 
-      for (final info in proto.allInfos) {
+      for (final info in proto.allInfos.entries) {
         final value = info.value;
         if (value.hasLibraryInfo()) {
           expect(value.serializedId,

--- a/tool/update_proto.sh
+++ b/tool/update_proto.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Expected exactly one argument which is the protoc_plugin version to use"
+else
+    echo "Using protoc_plugin version $1"
+    pub global activate protoc_plugin "$1"
+fi
+
+protoc --proto_path="." --dart_out=lib/src/proto info.proto
+dartfmt -w lib/src/proto


### PR DESCRIPTION
Also add a script `tool/update_proto.sh` to regenerate proto sources.

I am trying to synchronize internal and external Dart protobuf implementations, and dart2js_info is currently incompatible with the newest protobuf (in particular, it uses old BuilderInfo API and does not use Dart native maps for protobuf maps).

Is it possible to merge this PR into a separate branch (e.g. `newproto`) until landed internally?