### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/bin/src/deferred_library_check.dart
+++ b/bin/src/deferred_library_check.dart
@@ -35,7 +35,6 @@
 /// specification.
 library dart2js_info.bin.deferred_library_check;
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 

--- a/test/hello_world_deferred/hello_world_deferred.dart
+++ b/test/hello_world_deferred/hello_world_deferred.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'deferred_import.dart' deferred as deferred_import;
 
 Future<void> main() async {


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core