### PR TITLE
Remove dependency on quiver.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   fixnum: ^0.10.5
   path: ^1.3.6
   protobuf: ^1.0.1
-  quiver: '>=0.29.0 <3.0.0'
   shelf: ^0.7.3
   shelf_static: ^0.2.4
   yaml: ^2.1.0


### PR DESCRIPTION
The dart2js_info package is included in the Dart SDK. This reduces the dependencies on another third-party package.