### PR TITLE
Make dart2js_info compatible with null-safe protobuf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.3
+
+* Broaden version ranges for `fixnum` and `protobuf` dependencies to make
+  `dart2js_info` compatible with null-safe `protobuf` version.
+
 ## 0.6.2
 
 * Update `protobuf` dependency.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart2js_info
-version: 0.6.2
+version: 0.6.3
 
 description: >
   Libraries and tools to process data produced when running dart2js with
@@ -14,9 +14,9 @@ dependencies:
   args: ^1.4.3
   charcode: ^1.1.0
   collection: ^1.10.1
-  fixnum: ^0.10.5
+  fixnum: '>=0.10.5 <2.0.0'
   path: ^1.3.6
-  protobuf: ^1.0.1
+  protobuf: '>=1.0.1 <3.0.0'
   shelf: ^0.7.3
   shelf_static: ^0.2.4
   yaml: ^2.1.0


### PR DESCRIPTION
Just expand upper bounds for `fixnum` and `protobuf` 