### PR TITLE
Make compatible with null-safe args package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.4
+
+* Make compatible with the null-safe version of `args`. 
+
 ## 0.6.3
 
 * Broaden version ranges for `fixnum` and `protobuf` dependencies to make

--- a/bin/src/usage_exception.dart
+++ b/bin/src/usage_exception.dart
@@ -6,7 +6,9 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 
 abstract class PrintUsageException implements Command<void> {
-  void usageException(String message) {
+  // TODO(rnystrom): Use "Never" for the return type when this package is
+  // migrated to null safety.
+  usageException(String message) {
     print(message);
     printUsage();
     exit(1);


### PR DESCRIPTION
The return type of usageException() is Never in the migrated package.
Externally, dart2js_info does not need to worry about this because its
constraint on args keeps it on the unmigrated version.

But to roll the migrated args into the Dart SDK and google3, it needs to
be compatible with dart2js_info. This tiny change here makes the
usageException() override agnostic and work with both the unmigrated and
migrated versions of args. I tested the latter locally with a dependency
override.